### PR TITLE
feat(provider): streaming support in runTools

### DIFF
--- a/src/anthropic/Client.zig
+++ b/src/anthropic/Client.zig
@@ -317,6 +317,110 @@ pub fn createMessageStreamFromText(
     return self.createMessageStream(model, &messages, max_tokens, config, context, callback);
 }
 
+/// Reassembles a streamed Messages response into the same `MessageResponse` the
+/// non-streaming `createMessage` returns, firing `on_text_fn` for each text
+/// delta as it arrives. Drive it by passing `&acc` and `onEvent` to
+/// `createMessageStream`, then call `response()`. All storage lives in `arena`.
+pub const StreamAccumulator = struct {
+    arena: std.mem.Allocator,
+    on_text_ctx: *anyopaque,
+    on_text_fn: *const fn (*anyopaque, []const u8) void,
+    text: std.ArrayListUnmanaged(u8) = .empty,
+    tool_blocks: std.ArrayListUnmanaged(ToolBlock) = .empty,
+    stop_reason: ?types.StopReason = null,
+    usage: types.Usage = .{},
+    err: ?error{OutOfMemory} = null,
+
+    const ToolBlock = struct {
+        index: i32,
+        id: []const u8,
+        name: []const u8,
+        json: std.ArrayListUnmanaged(u8) = .empty,
+    };
+
+    pub fn init(
+        arena: std.mem.Allocator,
+        on_text_ctx: *anyopaque,
+        on_text_fn: *const fn (*anyopaque, []const u8) void,
+    ) StreamAccumulator {
+        return .{ .arena = arena, .on_text_ctx = on_text_ctx, .on_text_fn = on_text_fn };
+    }
+
+    pub fn onEvent(self: *StreamAccumulator, event: StreamEvent) void {
+        self.handle(event) catch |e| {
+            self.err = e;
+        };
+    }
+
+    fn handle(self: *StreamAccumulator, event: StreamEvent) error{OutOfMemory}!void {
+        const et = event.type orelse return;
+        if (std.mem.eql(u8, et, "content_block_start")) {
+            const cb = event.content_block orelse return;
+            const ct = cb.type orelse return;
+            if (std.mem.eql(u8, ct, "tool_use")) {
+                try self.tool_blocks.append(self.arena, .{
+                    .index = event.index orelse 0,
+                    .id = if (cb.id) |id| try self.arena.dupe(u8, id) else "",
+                    .name = if (cb.name) |n| try self.arena.dupe(u8, n) else "",
+                });
+            }
+        } else if (std.mem.eql(u8, et, "content_block_delta")) {
+            const d = event.delta orelse return;
+            const dt = d.type orelse return;
+            if (std.mem.eql(u8, dt, "text_delta")) {
+                if (d.text) |txt| {
+                    try self.text.appendSlice(self.arena, txt);
+                    self.on_text_fn(self.on_text_ctx, txt);
+                }
+            } else if (std.mem.eql(u8, dt, "input_json_delta")) {
+                if (d.partial_json) |pj| {
+                    const idx = event.index orelse return;
+                    for (self.tool_blocks.items) |*b| {
+                        if (b.index == idx) {
+                            try b.json.appendSlice(self.arena, pj);
+                            break;
+                        }
+                    }
+                }
+            }
+        } else if (std.mem.eql(u8, et, "message_start")) {
+            if (event.message) |m| {
+                if (m.usage) |u| self.usage = u;
+            }
+        } else if (std.mem.eql(u8, et, "message_delta")) {
+            if (event.delta) |d| {
+                if (d.stop_reason) |sr| self.stop_reason = sr;
+            }
+            // message_delta reports the cumulative output count; keep the
+            // input/cache counts from message_start.
+            if (event.usage) |u| {
+                if (u.output_tokens) |ot| self.usage.output_tokens = ot;
+            }
+        }
+    }
+
+    /// Assemble the accumulated deltas into a `MessageResponse`. Call once, after
+    /// the stream completes and `err` is clear.
+    pub fn response(self: *StreamAccumulator) error{OutOfMemory}!MessageResponse {
+        var blocks: std.ArrayListUnmanaged(types.ContentBlock) = .empty;
+        if (self.text.items.len > 0) {
+            try blocks.append(self.arena, .{ .type = "text", .text = self.text.items });
+        }
+        for (self.tool_blocks.items) |tb| {
+            const input: ?std.json.Value = if (tb.json.items.len > 0)
+                (std.json.parseFromSliceLeaky(std.json.Value, self.arena, tb.json.items, .{}) catch null)
+            else
+                null;
+            try blocks.append(self.arena, .{ .type = "tool_use", .id = tb.id, .name = tb.name, .input = input });
+        }
+        return .{
+            .content = if (blocks.items.len > 0) blocks.items else null,
+            .stop_reason = self.stop_reason,
+            .usage = self.usage,
+        };
+    }
+};
+
 // --- Models ---
 
 /// List available models.
@@ -346,4 +450,52 @@ test "listModels: missing api key" {
     var client = Client.init(std.testing.allocator, "", .{});
     defer client.deinit();
     try std.testing.expectError(error.MissingApiKey, client.listModels());
+}
+
+const TextProbe = struct {
+    count: usize = 0,
+    text: std.ArrayListUnmanaged(u8) = .empty,
+
+    fn cb(ptr: *anyopaque, delta: []const u8) void {
+        const self: *TextProbe = @ptrCast(@alignCast(ptr));
+        self.count += 1;
+        self.text.appendSlice(std.testing.allocator, delta) catch {};
+    }
+};
+
+test "StreamAccumulator reassembles text and a tool_use block into a MessageResponse" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var probe = TextProbe{};
+    defer probe.text.deinit(std.testing.allocator);
+
+    var acc = StreamAccumulator.init(arena.allocator(), &probe, TextProbe.cb);
+    const events = [_]StreamEvent{
+        .{ .type = "message_start", .message = .{ .usage = .{ .input_tokens = 10, .output_tokens = 1 } } },
+        .{ .type = "content_block_start", .index = 0, .content_block = .{ .type = "text" } },
+        .{ .type = "content_block_delta", .index = 0, .delta = .{ .type = "text_delta", .text = "Let me " } },
+        .{ .type = "content_block_delta", .index = 0, .delta = .{ .type = "text_delta", .text = "search." } },
+        .{ .type = "content_block_start", .index = 1, .content_block = .{ .type = "tool_use", .id = "toolu_1", .name = "search" } },
+        .{ .type = "content_block_delta", .index = 1, .delta = .{ .type = "input_json_delta", .partial_json = "{\"q\":" } },
+        .{ .type = "content_block_delta", .index = 1, .delta = .{ .type = "input_json_delta", .partial_json = "\"cats\"}" } },
+        .{ .type = "content_block_stop", .index = 1 },
+        .{ .type = "message_delta", .delta = .{ .stop_reason = .tool_use }, .usage = .{ .output_tokens = 25 } },
+        .{ .type = "message_stop" },
+    };
+    for (events) |ev| acc.onEvent(ev);
+    try std.testing.expect(acc.err == null);
+
+    const msg = try acc.response();
+    try std.testing.expectEqual(@as(usize, 2), probe.count);
+    try std.testing.expectEqualStrings("Let me search.", probe.text.items);
+    try std.testing.expectEqualStrings("Let me search.", msg.text().?);
+    try std.testing.expectEqual(types.StopReason.tool_use, msg.stop_reason.?);
+    try std.testing.expectEqual(@as(?i32, 10), msg.usage.?.input_tokens);
+    try std.testing.expectEqual(@as(?i32, 25), msg.usage.?.output_tokens);
+
+    const tool = msg.firstToolUse().?;
+    try std.testing.expectEqualStrings("toolu_1", tool.id.?);
+    try std.testing.expectEqualStrings("search", tool.name.?);
+    try std.testing.expectEqualStrings("cats", tool.input.?.object.get("q").?.string);
 }

--- a/src/anthropic/Client.zig
+++ b/src/anthropic/Client.zig
@@ -240,6 +240,9 @@ pub fn createMessageStream(
         .extra_headers = &auth,
         .headers = .{
             .content_type = .{ .override = "application/json" },
+            // Read the SSE stream as plain text: the raw reader does not
+            // decompress, so a gzip'd body would arrive as unparseable bytes.
+            .accept_encoding = .{ .override = "identity" },
         },
         .redirect_behavior = .init(5),
     });

--- a/src/gemini/Client.zig
+++ b/src/gemini/Client.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const http = @import("../http.zig");
 const retry = @import("../retry.zig");
+const json = @import("../json.zig");
 
 pub const RetryPolicy = retry.RetryPolicy;
 
@@ -407,6 +408,78 @@ pub fn generateContentStreamFromText(
     const contents = [_]Content{.{ .role = "user", .parts = &parts }};
     return self.generateContentStream(model, &contents, config, options, context, callback);
 }
+
+/// Reassembles a streamed generation into the same `GenerateContentResponse` the
+/// non-streaming `generateContent` returns. Text parts are concatenated (and
+/// forwarded to `on_text_fn`); function-call parts arrive complete per chunk;
+/// the last `finishReason` and `usageMetadata` win. All storage lives in `arena`.
+pub const StreamAccumulator = struct {
+    arena: std.mem.Allocator,
+    on_text_ctx: *anyopaque,
+    on_text_fn: *const fn (*anyopaque, []const u8) void,
+    text: std.ArrayListUnmanaged(u8) = .empty,
+    fn_parts: std.ArrayListUnmanaged(Part) = .empty,
+    finish_reason: ?types.FinishReason = null,
+    usage: ?types.UsageMetadata = null,
+    err: ?error{OutOfMemory} = null,
+
+    pub fn init(
+        arena: std.mem.Allocator,
+        on_text_ctx: *anyopaque,
+        on_text_fn: *const fn (*anyopaque, []const u8) void,
+    ) StreamAccumulator {
+        return .{ .arena = arena, .on_text_ctx = on_text_ctx, .on_text_fn = on_text_fn };
+    }
+
+    pub fn onEvent(self: *StreamAccumulator, chunk: GenerateContentResponse) void {
+        self.handle(chunk) catch |e| {
+            self.err = e;
+        };
+    }
+
+    fn handle(self: *StreamAccumulator, chunk: GenerateContentResponse) error{OutOfMemory}!void {
+        // `text()` already skips `thought` parts, so this never leaks reasoning.
+        if (chunk.text()) |txt| {
+            if (txt.len > 0) {
+                try self.text.appendSlice(self.arena, txt);
+                self.on_text_fn(self.on_text_ctx, txt);
+            }
+        }
+        if (chunk.usageMetadata) |u| self.usage = u;
+        const candidates = chunk.candidates orelse return;
+        if (candidates.len == 0) return;
+        if (candidates[0].finishReason) |fr| self.finish_reason = fr;
+        const content = candidates[0].content orelse return;
+        for (content.parts) |p| {
+            const fc = p.functionCall orelse continue;
+            // Strings/values point into the transient parsed chunk; dupe them.
+            try self.fn_parts.append(self.arena, .{
+                .functionCall = .{
+                    .id = if (fc.id) |id| try self.arena.dupe(u8, id) else null,
+                    .name = if (fc.name) |n| try self.arena.dupe(u8, n) else null,
+                    .args = if (fc.args) |v| try json.dupeValue(self.arena, v) else null,
+                },
+                .thoughtSignature = if (p.thoughtSignature) |ts| try self.arena.dupe(u8, ts) else null,
+            });
+        }
+    }
+
+    /// Assemble the accumulated deltas into a `GenerateContentResponse`. Call
+    /// once, after the stream completes and `err` is clear.
+    pub fn response(self: *StreamAccumulator) error{OutOfMemory}!GenerateContentResponse {
+        var parts: std.ArrayListUnmanaged(Part) = .empty;
+        if (self.text.items.len > 0) {
+            try parts.append(self.arena, .{ .text = self.text.items });
+        }
+        try parts.appendSlice(self.arena, self.fn_parts.items);
+        const candidate = types.Candidate{
+            .content = .{ .parts = parts.items },
+            .finishReason = self.finish_reason,
+        };
+        const candidates = try self.arena.dupe(types.Candidate, &.{candidate});
+        return .{ .candidates = candidates, .usageMetadata = self.usage };
+    }
+};
 
 // --- Model Management ---
 
@@ -1059,4 +1132,47 @@ test "isChatModel keeps multimodal text+image variants" {
     // though they also handle images.
     try std.testing.expect(isChatModel(T.m("models/gemini-2.5-flash-image", &generate)));
     try std.testing.expect(isChatModel(T.m("models/nano-banana-pro-preview", &generate)));
+}
+
+const TextProbe = struct {
+    count: usize = 0,
+    text: std.ArrayListUnmanaged(u8) = .empty,
+
+    fn cb(ptr: *anyopaque, delta: []const u8) void {
+        const self: *TextProbe = @ptrCast(@alignCast(ptr));
+        self.count += 1;
+        self.text.appendSlice(std.testing.allocator, delta) catch {};
+    }
+};
+
+test "StreamAccumulator reassembles text and a function call into a GenerateContentResponse" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var probe = TextProbe{};
+    defer probe.text.deinit(std.testing.allocator);
+
+    var args = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "{\"q\":\"birds\"}", .{});
+    defer args.deinit();
+
+    var acc = StreamAccumulator.init(arena.allocator(), &probe, TextProbe.cb);
+    const text_a = [_]Part{.{ .text = "Search" }};
+    const text_b = [_]Part{.{ .text = "ing." }};
+    const fc = [_]Part{.{ .functionCall = .{ .name = "search", .args = args.value } }};
+    const chunks = [_]GenerateContentResponse{
+        .{ .candidates = &.{.{ .content = .{ .parts = &text_a } }} },
+        .{ .candidates = &.{.{ .content = .{ .parts = &text_b } }} },
+        .{ .candidates = &.{.{ .content = .{ .parts = &fc }, .finishReason = .STOP }} },
+        .{ .usageMetadata = .{ .promptTokenCount = 8, .candidatesTokenCount = 4, .totalTokenCount = 12 } },
+    };
+    for (chunks) |c| acc.onEvent(c);
+    try std.testing.expect(acc.err == null);
+
+    const resp = try acc.response();
+    try std.testing.expectEqual(@as(usize, 2), probe.count);
+    try std.testing.expectEqualStrings("Searching.", resp.text().?);
+    try std.testing.expectEqual(@as(?i32, 4), resp.usageMetadata.?.candidatesTokenCount);
+
+    const call = resp.firstFunctionCall().?;
+    try std.testing.expectEqualStrings("search", call.name.?);
+    try std.testing.expectEqualStrings("birds", call.args.?.object.get("q").?.string);
 }

--- a/src/gemini/Client.zig
+++ b/src/gemini/Client.zig
@@ -336,6 +336,9 @@ pub fn generateContentStream(
         .extra_headers = &auth,
         .headers = .{
             .content_type = .{ .override = "application/json" },
+            // Read the SSE stream as plain text: the raw reader does not
+            // decompress, so a gzip'd body would arrive as unparseable bytes.
+            .accept_encoding = .{ .override = "identity" },
         },
         .redirect_behavior = .init(5),
     });

--- a/src/openai/Client.zig
+++ b/src/openai/Client.zig
@@ -443,6 +443,182 @@ pub fn chatCompletionStreamFromText(
     return self.chatCompletionStream(model, &messages, config, context, callback);
 }
 
+/// Reassembles a streamed chat completion into the same `ChatCompletionResponse`
+/// the non-streaming `chatCompletion` returns, correlating tool-call argument
+/// fragments by their delta index and firing `on_text_fn` per content delta.
+/// Drive it by passing `&acc` and `onEvent` to `chatCompletionStream`, then call
+/// `response()`. All storage lives in `arena`.
+pub const StreamAccumulator = struct {
+    arena: std.mem.Allocator,
+    on_text_ctx: *anyopaque,
+    on_text_fn: *const fn (*anyopaque, []const u8) void,
+    content: std.ArrayListUnmanaged(u8) = .empty,
+    calls: std.ArrayListUnmanaged(CallFragment) = .empty,
+    finish_reason: ?types.FinishReason = null,
+    usage: ?types.Usage = null,
+    err: ?error{OutOfMemory} = null,
+
+    const CallFragment = struct {
+        index: i32,
+        id: std.ArrayListUnmanaged(u8) = .empty,
+        name: std.ArrayListUnmanaged(u8) = .empty,
+        args: std.ArrayListUnmanaged(u8) = .empty,
+    };
+
+    pub fn init(
+        arena: std.mem.Allocator,
+        on_text_ctx: *anyopaque,
+        on_text_fn: *const fn (*anyopaque, []const u8) void,
+    ) StreamAccumulator {
+        return .{ .arena = arena, .on_text_ctx = on_text_ctx, .on_text_fn = on_text_fn };
+    }
+
+    pub fn onEvent(self: *StreamAccumulator, chunk: ChatCompletionResponse) void {
+        self.handle(chunk) catch |e| {
+            self.err = e;
+        };
+    }
+
+    fn slot(self: *StreamAccumulator, idx: i32) error{OutOfMemory}!*CallFragment {
+        for (self.calls.items) |*c| {
+            if (c.index == idx) return c;
+        }
+        try self.calls.append(self.arena, .{ .index = idx });
+        return &self.calls.items[self.calls.items.len - 1];
+    }
+
+    fn handle(self: *StreamAccumulator, chunk: ChatCompletionResponse) error{OutOfMemory}!void {
+        // The final `include_usage` chunk carries usage with no choices.
+        if (chunk.usage != null) self.usage = chunk.usage;
+        const choices = chunk.choices orelse return;
+        if (choices.len == 0) return;
+        const c0 = choices[0];
+        if (c0.finish_reason) |fr| self.finish_reason = fr;
+        const delta = c0.delta orelse return;
+        if (delta.content) |txt| {
+            if (txt.len > 0) {
+                try self.content.appendSlice(self.arena, txt);
+                self.on_text_fn(self.on_text_ctx, txt);
+            }
+        }
+        if (delta.tool_calls) |tcs| {
+            for (tcs, 0..) |tc, i| {
+                const call = try self.slot(tc.index orelse @intCast(i));
+                if (tc.id) |id| {
+                    call.id.clearRetainingCapacity();
+                    try call.id.appendSlice(self.arena, id);
+                }
+                if (tc.function) |f| {
+                    if (f.name) |n| {
+                        call.name.clearRetainingCapacity();
+                        try call.name.appendSlice(self.arena, n);
+                    }
+                    if (f.arguments) |a| try call.args.appendSlice(self.arena, a);
+                }
+            }
+        }
+    }
+
+    /// Assemble the accumulated deltas into a `ChatCompletionResponse`. Call
+    /// once, after the stream completes and `err` is clear.
+    pub fn response(self: *StreamAccumulator) error{OutOfMemory}!ChatCompletionResponse {
+        var tool_calls: std.ArrayListUnmanaged(types.ToolCall) = .empty;
+        for (self.calls.items) |c| {
+            try tool_calls.append(self.arena, .{
+                .id = c.id.items,
+                .type = "function",
+                .function = .{ .name = c.name.items, .arguments = c.args.items },
+            });
+        }
+        const message = types.Message{
+            .role = .assistant,
+            .content = if (self.content.items.len > 0) self.content.items else null,
+            .tool_calls = if (tool_calls.items.len > 0) tool_calls.items else null,
+        };
+        const choices = try self.arena.dupe(types.Choice, &.{.{ .index = 0, .message = message, .finish_reason = self.finish_reason }});
+        return .{ .choices = choices, .usage = self.usage };
+    }
+};
+
+/// Reassembles a streamed Responses-API response into the same `ResponsesResponse`
+/// the non-streaming `createResponse` returns. Text arrives as `output_text.delta`
+/// events (forwarded to `on_text_fn`); each `output_item.done` carries a complete
+/// `function_call` item; the terminal `response.completed`/`incomplete` event
+/// carries usage and status. All storage lives in `arena`.
+pub const ResponsesStreamAccumulator = struct {
+    arena: std.mem.Allocator,
+    on_text_ctx: *anyopaque,
+    on_text_fn: *const fn (*anyopaque, []const u8) void,
+    text: std.ArrayListUnmanaged(u8) = .empty,
+    calls: std.ArrayListUnmanaged(types.ResponseOutputItem) = .empty,
+    usage: ?types.ResponsesUsage = null,
+    incomplete_reason: ?[]const u8 = null,
+    err: ?error{OutOfMemory} = null,
+
+    pub fn init(
+        arena: std.mem.Allocator,
+        on_text_ctx: *anyopaque,
+        on_text_fn: *const fn (*anyopaque, []const u8) void,
+    ) ResponsesStreamAccumulator {
+        return .{ .arena = arena, .on_text_ctx = on_text_ctx, .on_text_fn = on_text_fn };
+    }
+
+    pub fn onEvent(self: *ResponsesStreamAccumulator, event: ResponseStreamEvent) void {
+        self.handle(event) catch |e| {
+            self.err = e;
+        };
+    }
+
+    fn handle(self: *ResponsesStreamAccumulator, event: ResponseStreamEvent) error{OutOfMemory}!void {
+        const t = event.type orelse return;
+        if (std.mem.eql(u8, t, "response.output_text.delta")) {
+            if (event.delta) |d| {
+                if (d.len > 0) {
+                    try self.text.appendSlice(self.arena, d);
+                    self.on_text_fn(self.on_text_ctx, d);
+                }
+            }
+        } else if (std.mem.eql(u8, t, "response.output_item.done")) {
+            const item = event.item orelse return;
+            const it = item.type orelse return;
+            if (std.mem.eql(u8, it, "function_call")) {
+                // Strings point into the transient parsed event; dupe them.
+                try self.calls.append(self.arena, .{
+                    .type = "function_call",
+                    .call_id = if (item.call_id) |c| try self.arena.dupe(u8, c) else null,
+                    .name = if (item.name) |n| try self.arena.dupe(u8, n) else null,
+                    .arguments = if (item.arguments) |a| try self.arena.dupe(u8, a) else null,
+                });
+            }
+        } else if (std.mem.eql(u8, t, "response.completed") or std.mem.eql(u8, t, "response.incomplete")) {
+            if (event.response) |r| {
+                // Usage is all ints — a value copy outlives the event; the
+                // incomplete reason is a string and must be duped.
+                if (r.usage) |u| self.usage = u;
+                if (r.incomplete_details) |d| {
+                    self.incomplete_reason = if (d.reason) |rr| try self.arena.dupe(u8, rr) else null;
+                }
+            }
+        }
+    }
+
+    /// Assemble the accumulated deltas into a `ResponsesResponse`. Call once,
+    /// after the stream completes and `err` is clear.
+    pub fn response(self: *ResponsesStreamAccumulator) error{OutOfMemory}!ResponsesResponse {
+        var output: std.ArrayListUnmanaged(types.ResponseOutputItem) = .empty;
+        if (self.text.items.len > 0) {
+            const content = try self.arena.dupe(types.ResponseOutputContent, &.{.{ .type = "output_text", .text = self.text.items }});
+            try output.append(self.arena, .{ .type = "message", .role = "assistant", .content = content });
+        }
+        try output.appendSlice(self.arena, self.calls.items);
+        return .{
+            .output = if (output.items.len > 0) output.items else null,
+            .usage = self.usage,
+            .incomplete_details = if (self.incomplete_reason) |r| .{ .reason = r } else null,
+        };
+    }
+};
+
 // --- Embeddings ---
 
 /// Configuration for embedding requests.
@@ -584,4 +760,81 @@ test "isChatModel drops non-chat" {
     try std.testing.expect(!isChatModel(T.m("gpt-4o-realtime-preview")));
     try std.testing.expect(!isChatModel(T.m("gpt-4o-transcribe")));
     try std.testing.expect(!isChatModel(T.m("gpt-4o-mini-tts")));
+}
+
+const TextProbe = struct {
+    count: usize = 0,
+    text: std.ArrayListUnmanaged(u8) = .empty,
+
+    fn cb(ptr: *anyopaque, delta: []const u8) void {
+        const self: *TextProbe = @ptrCast(@alignCast(ptr));
+        self.count += 1;
+        self.text.appendSlice(std.testing.allocator, delta) catch {};
+    }
+};
+
+test "StreamAccumulator reassembles chat text and correlates tool-call fragments by index" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var probe = TextProbe{};
+    defer probe.text.deinit(std.testing.allocator);
+
+    var acc = StreamAccumulator.init(arena.allocator(), &probe, TextProbe.cb);
+    const chunks = [_]ChatCompletionResponse{
+        .{ .choices = &.{.{ .index = 0, .delta = .{ .content = "Hel" } }} },
+        .{ .choices = &.{.{ .index = 0, .delta = .{ .content = "lo" } }} },
+        .{ .choices = &.{.{ .index = 0, .delta = .{ .tool_calls = &.{.{ .index = 0, .id = "call_1", .type = "function", .function = .{ .name = "search", .arguments = "" } }} } }} },
+        .{ .choices = &.{.{ .index = 0, .delta = .{ .tool_calls = &.{.{ .index = 0, .function = .{ .arguments = "{\"q\":" } }} } }} },
+        .{ .choices = &.{.{ .index = 0, .delta = .{ .tool_calls = &.{.{ .index = 0, .function = .{ .arguments = "\"dogs\"}" } }} } }} },
+        .{ .choices = &.{.{ .index = 0, .delta = .{}, .finish_reason = .tool_calls }} },
+        .{ .choices = &.{}, .usage = .{ .prompt_tokens = 5, .completion_tokens = 7, .total_tokens = 12 } },
+    };
+    for (chunks) |c| acc.onEvent(c);
+    try std.testing.expect(acc.err == null);
+
+    const resp = try acc.response();
+    try std.testing.expectEqual(@as(usize, 2), probe.count);
+    try std.testing.expectEqualStrings("Hello", resp.text().?);
+    try std.testing.expectEqual(@as(?i32, 7), resp.usage.?.completion_tokens);
+
+    const tc = resp.firstToolCall().?;
+    try std.testing.expectEqualStrings("call_1", tc.id.?);
+    try std.testing.expectEqualStrings("search", tc.function.?.name.?);
+    try std.testing.expectEqualStrings("{\"q\":\"dogs\"}", tc.function.?.arguments.?);
+}
+
+test "ResponsesStreamAccumulator reassembles text and a completed function-call item" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var probe = TextProbe{};
+    defer probe.text.deinit(std.testing.allocator);
+
+    var acc = ResponsesStreamAccumulator.init(arena.allocator(), &probe, TextProbe.cb);
+    const events = [_]ResponseStreamEvent{
+        .{ .type = "response.output_text.delta", .delta = "Search" },
+        .{ .type = "response.output_text.delta", .delta = "ing." },
+        .{ .type = "response.output_item.done", .item = .{ .type = "function_call", .call_id = "call_9", .name = "search", .arguments = "{\"q\":\"birds\"}" } },
+        .{ .type = "response.completed", .response = .{
+            .status = "completed",
+            .usage = .{ .input_tokens = 8, .output_tokens = 4, .total_tokens = 12 },
+        } },
+    };
+    for (events) |ev| acc.onEvent(ev);
+    try std.testing.expect(acc.err == null);
+
+    const resp = try acc.response();
+    try std.testing.expectEqual(@as(usize, 2), probe.count);
+    try std.testing.expectEqualStrings("Searching.", resp.text().?);
+    try std.testing.expectEqual(@as(?i32, 4), resp.usage.?.output_tokens);
+
+    const items = resp.output.?;
+    var fc: ?types.ResponseOutputItem = null;
+    for (items) |it| {
+        if (it.type) |t| if (std.mem.eql(u8, t, "function_call")) {
+            fc = it;
+        };
+    }
+    try std.testing.expectEqualStrings("call_9", fc.?.call_id.?);
+    try std.testing.expectEqualStrings("search", fc.?.name.?);
+    try std.testing.expectEqualStrings("{\"q\":\"birds\"}", fc.?.arguments.?);
 }

--- a/src/openai/Client.zig
+++ b/src/openai/Client.zig
@@ -10,6 +10,7 @@ const ChatCompletionRequest = types.ChatCompletionRequest;
 const ChatCompletionResponse = types.ChatCompletionResponse;
 const ResponsesRequest = types.ResponsesRequest;
 const ResponsesResponse = types.ResponsesResponse;
+const ResponseStreamEvent = types.ResponseStreamEvent;
 
 /// OpenAI API client. Provides access to chat completions, embeddings,
 /// and model management.
@@ -221,6 +222,99 @@ pub fn createResponse(self: *Client, request: ResponsesRequest) ApiError!Respons
     return self.fetchPost(url, request, ResponsesResponse);
 }
 
+/// Stream a model response via the Responses API (`POST /responses`). The
+/// `callback` fires per SSE event; `request.stream` is forced on. Unlike Chat
+/// Completions, this endpoint supports function tools together with reasoning
+/// on the gpt-5 family, so native OpenAI streams through here.
+pub fn createResponseStream(
+    self: *Client,
+    request: ResponsesRequest,
+    context: anytype,
+    callback: *const fn (@TypeOf(context), ResponseStreamEvent) void,
+) StreamError!void {
+    if (self.api_key.len == 0) return error.MissingApiKey;
+
+    const url = try std.fmt.allocPrint(self.allocator, "{s}/responses", .{self.base_url});
+    defer self.allocator.free(url);
+
+    var req_body = request;
+    req_body.stream = true;
+
+    var payload_buf: std.Io.Writer.Allocating = .init(self.allocator);
+    defer payload_buf.deinit();
+    std.json.Stringify.value(req_body, .{ .emit_null_optional_fields = false }, &payload_buf.writer) catch
+        return error.OutOfMemory;
+    const payload = payload_buf.written();
+
+    var hdr_buf: [4]std.http.Header = undefined;
+    const auth = try self.authHeaders(&hdr_buf);
+    const uri = try std.Uri.parse(url);
+    var req = try self.http_client.request(.POST, uri, .{
+        .extra_headers = auth,
+        .headers = .{
+            .content_type = .{ .override = "application/json" },
+            // Read the SSE stream as plain text: the raw reader does not
+            // decompress, so a gzip'd body would arrive as unparseable bytes.
+            .accept_encoding = .{ .override = "identity" },
+        },
+        .redirect_behavior = .init(5),
+    });
+    defer req.deinit();
+
+    // Let a SIGINT abort the blocking SSE read; poison the connection on any
+    // failed/aborted exchange so it isn't pooled with unknown framing.
+    var guard = http.armInterrupt(self.interrupt, &req);
+    defer guard.deinit();
+    errdefer guard.poison();
+
+    req.transfer_encoding = .{ .content_length = payload.len };
+    var bw = try req.sendBodyUnflushed(&.{});
+    try bw.writer.writeAll(payload);
+    try bw.end();
+    try req.connection.?.flush();
+
+    var redirect_buf: [0]u8 = undefined;
+    var response = try req.receiveHead(&redirect_buf);
+
+    const status_code: u10 = @intFromEnum(response.head.status);
+    if (status_code < 200 or status_code >= 300) {
+        self.setErrorDetail(status_code, "");
+        return error.ApiError;
+    }
+
+    const transfer_buf = try self.allocator.alloc(u8, 256 * 1024);
+    defer self.allocator.free(transfer_buf);
+    const reader = response.reader(transfer_buf);
+
+    while (true) {
+        const line = reader.takeDelimiter('\n') catch |err| switch (err) {
+            error.StreamTooLong => return error.InvalidSseData,
+            error.ReadFailed => {
+                guard.poison();
+                return;
+            },
+        } orelse return;
+
+        const trimmed = std.mem.trimRight(u8, line, "\r");
+        if (trimmed.len == 0) continue;
+
+        // Skip event: lines — the type is repeated in the data JSON.
+        if (std.mem.startsWith(u8, trimmed, "event: ")) continue;
+
+        if (std.mem.startsWith(u8, trimmed, "data: ")) {
+            const json_data = trimmed["data: ".len..];
+            if (std.mem.eql(u8, json_data, "[DONE]")) return;
+
+            const parsed = std.json.parseFromSlice(ResponseStreamEvent, self.allocator, json_data, .{ .ignore_unknown_fields = true }) catch |err| {
+                std.log.err("OpenAI responses streaming: failed to parse SSE chunk: {}", .{err});
+                return error.InvalidSseData;
+            };
+            defer parsed.deinit();
+            callback(context, parsed.value);
+        }
+    }
+}
+
 // --- Streaming ---
 
 pub const StreamError = error{
@@ -248,6 +342,8 @@ pub fn chatCompletionStream(
         .model = model,
         .messages = messages,
         .stream = true,
+        // Ask for the trailing usage chunk so streamed turns still report cost.
+        .stream_options = .{ .include_usage = true },
         .temperature = config.temperature,
         .max_completion_tokens = config.max_tokens,
         .top_p = config.top_p,
@@ -273,6 +369,9 @@ pub fn chatCompletionStream(
         .extra_headers = auth,
         .headers = .{
             .content_type = .{ .override = "application/json" },
+            // Read the SSE stream as plain text: the raw reader does not
+            // decompress, so a gzip'd body would arrive as unparseable bytes.
+            .accept_encoding = .{ .override = "identity" },
         },
         .redirect_behavior = .init(5),
     });

--- a/src/openai/types.zig
+++ b/src/openai/types.zig
@@ -49,6 +49,10 @@ pub const FunctionCall = struct {
 pub const ToolCall = struct {
     /// The unique ID of this tool call.
     id: ?[]const u8 = null,
+    /// Position of this tool call within the assistant message. Streaming
+    /// deltas carry it so argument fragments can be correlated across chunks;
+    /// omitted (null) in requests.
+    index: ?i32 = null,
     /// The type of tool (always "function").
     type: ?[]const u8 = null,
     /// The function call details.
@@ -99,6 +103,12 @@ pub const ResponseFormat = struct {
     type: ?[]const u8 = null,
 };
 
+/// Streaming-only request options.
+pub const StreamOptions = struct {
+    /// Emit a final chunk carrying token usage after the stream completes.
+    include_usage: ?bool = null,
+};
+
 // --- Request ---
 
 /// Request body for the chat completions endpoint.
@@ -122,6 +132,8 @@ pub const ChatCompletionRequest = struct {
     stop: ?[]const []const u8 = null,
     /// Whether to stream the response.
     stream: ?bool = null,
+    /// Streaming-only options (e.g. request a final usage chunk).
+    stream_options: ?StreamOptions = null,
     /// Tools the model may call.
     tools: ?[]const Tool = null,
     /// Controls which tool is called ("none", "auto", "required").
@@ -355,6 +367,18 @@ pub const ResponsesResponse = struct {
         }
         return null;
     }
+};
+
+/// A streaming event from the responses endpoint. The `type` field selects
+/// which of the other fields is populated: `response.output_text.delta` carries
+/// an incremental `delta`; `response.output_item.done` carries a complete
+/// `item` (a `function_call` item has its full `arguments`); `response.completed`
+/// / `response.incomplete` carry the terminal `response` with usage and status.
+pub const ResponseStreamEvent = struct {
+    type: ?[]const u8 = null,
+    delta: ?[]const u8 = null,
+    item: ?ResponseOutputItem = null,
+    response: ?ResponsesResponse = null,
 };
 
 // --- Embeddings ---

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -546,35 +546,7 @@ pub const Client = union(enum) {
                 });
                 defer response.deinit();
 
-                var result = GenerateResult.init(g.allocator);
-                errdefer result.deinit();
-                if (response.value.text()) |t| {
-                    result.text = try result.arena.allocator().dupe(u8, t);
-                }
-                result.finish_reason = mapGeminiFinishReason(response.value);
-                result.usage = mapGeminiUsage(response.value);
-
-                if (response.value.candidates) |candidates| {
-                    if (candidates.len > 0) {
-                        if (candidates[0].content) |content| {
-                            var tool_calls: std.ArrayList(ToolCall) = .empty;
-                            for (content.parts) |p| {
-                                if (p.functionCall) |fc| {
-                                    try tool_calls.append(result.arena.allocator(), .{
-                                        .id = if (fc.id) |id| try result.arena.allocator().dupe(u8, id) else "",
-                                        .name = if (fc.name) |n| try result.arena.allocator().dupe(u8, n) else "",
-                                        .arguments = if (fc.args) |v| try json.dupeValue(result.arena.allocator(), v) else null,
-                                        .thought_signature = if (p.thoughtSignature) |ts| try result.arena.allocator().dupe(u8, ts) else null,
-                                    });
-                                }
-                            }
-                            if (tool_calls.items.len > 0) {
-                                result.tool_calls = try tool_calls.toOwnedSlice(result.arena.allocator());
-                            }
-                        }
-                    }
-                }
-                return result;
+                return geminiResult(g.allocator, response.value);
             },
             .openai => |o| {
                 var req_arena = std.heap.ArenaAllocator.init(o.allocator);
@@ -598,36 +570,7 @@ pub const Client = union(enum) {
                 });
                 defer response.deinit();
 
-                var result = GenerateResult.init(o.allocator);
-                errdefer result.deinit();
-                const ga = result.arena.allocator();
-
-                if (response.value.text()) |t| {
-                    result.text = try ga.dupe(u8, t);
-                }
-                result.finish_reason = mapOpenAIResponsesFinishReason(response.value);
-                result.usage = mapOpenAIResponsesUsage(response.value);
-
-                if (response.value.output) |items| {
-                    var tool_calls: std.ArrayList(ToolCall) = .empty;
-                    for (items) |item| {
-                        const item_type = item.type orelse continue;
-                        if (!std.mem.eql(u8, item_type, "function_call")) continue;
-                        const args_val: ?std.json.Value = if (item.arguments) |a|
-                            (std.json.parseFromSliceLeaky(std.json.Value, ga, a, .{}) catch null)
-                        else
-                            null;
-                        try tool_calls.append(ga, .{
-                            .id = if (item.call_id) |id| try ga.dupe(u8, id) else "",
-                            .name = if (item.name) |n| try ga.dupe(u8, n) else "",
-                            .arguments = args_val,
-                        });
-                    }
-                    if (tool_calls.items.len > 0) {
-                        result.tool_calls = try tool_calls.toOwnedSlice(ga);
-                    }
-                }
-                return result;
+                return openAiResponsesResult(o.allocator, response.value);
             },
             // Native `/api/chat` so `num_ctx` can be sized — see `openai/ollama.zig`.
             .ollama => |o| {
@@ -702,41 +645,7 @@ pub const Client = union(enum) {
                 var response = try o.chatCompletion(model, oai_messages, mapOpenAICompletionConfig(config, tools));
                 defer response.deinit();
 
-                var result = GenerateResult.init(o.allocator);
-                errdefer result.deinit();
-                const ga = result.arena.allocator();
-
-                if (response.value.text()) |t| {
-                    if (t.len > 0) result.text = try ga.dupe(u8, t);
-                }
-                result.finish_reason = mapOpenAIFinishReason(response.value);
-                result.usage = mapOpenAIUsage(response.value);
-
-                extract: {
-                    const choices = response.value.choices orelse break :extract;
-                    if (choices.len == 0) break :extract;
-                    const msg = choices[0].message orelse break :extract;
-                    const calls = msg.tool_calls orelse break :extract;
-
-                    var tool_calls: std.ArrayList(ToolCall) = .empty;
-                    for (calls) |call| {
-                        const f = call.function orelse continue;
-                        // Chat Completions returns arguments as a JSON string.
-                        const args_val: ?std.json.Value = if (f.arguments) |a|
-                            (std.json.parseFromSliceLeaky(std.json.Value, ga, a, .{}) catch null)
-                        else
-                            null;
-                        try tool_calls.append(ga, .{
-                            .id = if (call.id) |id| try ga.dupe(u8, id) else "",
-                            .name = if (f.name) |n| try ga.dupe(u8, n) else "",
-                            .arguments = args_val,
-                        });
-                    }
-                    if (tool_calls.items.len > 0) {
-                        result.tool_calls = try tool_calls.toOwnedSlice(ga);
-                    }
-                }
-                return result;
+                return openAiChatResult(o.allocator, response.value);
             },
             .anthropic => |a| {
                 var req_arena = std.heap.ArenaAllocator.init(a.allocator);
@@ -767,32 +676,7 @@ pub const Client = union(enum) {
                 });
                 defer response.deinit();
 
-                var result = GenerateResult.init(a.allocator);
-                errdefer result.deinit();
-                if (response.value.text()) |t| {
-                    result.text = try result.arena.allocator().dupe(u8, t);
-                }
-                result.finish_reason = mapAnthropicFinishReason(response.value);
-                result.usage = mapAnthropicUsage(response.value);
-
-                if (response.value.content) |blocks| {
-                    var tool_calls: std.ArrayList(ToolCall) = .empty;
-                    for (blocks) |block| {
-                        if (block.type) |t| {
-                            if (std.mem.eql(u8, t, "tool_use")) {
-                                try tool_calls.append(result.arena.allocator(), .{
-                                    .id = if (block.id) |id| try result.arena.allocator().dupe(u8, id) else "",
-                                    .name = if (block.name) |n| try result.arena.allocator().dupe(u8, n) else "",
-                                    .arguments = if (block.input) |v| try json.dupeValue(result.arena.allocator(), v) else null,
-                                });
-                            }
-                        }
-                    }
-                    if (tool_calls.items.len > 0) {
-                        result.tool_calls = try tool_calls.toOwnedSlice(result.arena.allocator());
-                    }
-                }
-                return result;
+                return anthropicResult(a.allocator, response.value);
             },
         }
     }
@@ -930,10 +814,6 @@ pub const Client = union(enum) {
     ) Error!GenerateResult {
         switch (self) {
             .anthropic => |a| {
-                var result = GenerateResult.init(a.allocator);
-                errdefer result.deinit();
-                const ra = result.arena.allocator();
-
                 var req_arena = std.heap.ArenaAllocator.init(a.allocator);
                 defer req_arena.deinit();
                 const req_alloc = req_arena.allocator();
@@ -947,7 +827,7 @@ pub const Client = union(enum) {
                 const tools = if (config.tools) |t| try mapAnthropicTools(req_alloc, t) else null;
                 const reasoning = mapEffortToAnthropic(config.effort, config.max_tokens orelse 4096);
 
-                var accum = AnthropicAccum{ .alloc = ra, .on_text = on_text };
+                var acc = anthropic_mod.StreamAccumulator.init(req_alloc, on_text.context, on_text.onText);
                 a.createMessageStream(model, ant_messages, reasoning.max_tokens, .{
                     .system = system_blocks,
                     .temperature = config.temperature,
@@ -957,19 +837,14 @@ pub const Client = union(enum) {
                     .tool_choice = mapToolChoiceToAnthropic(config.tool_choice),
                     .thinking = reasoning.thinking,
                     .output_config = reasoning.output_config,
-                }, &accum, AnthropicAccum.onEvent) catch |err| switch (err) {
+                }, &acc, anthropic_mod.StreamAccumulator.onEvent) catch |err| switch (err) {
                     error.OutOfMemory => return error.OutOfMemory,
                     else => return error.ApiError,
                 };
-                if (accum.err) |e| return e;
-                try accum.build(&result);
-                return result;
+                if (acc.err) |e| return e;
+                return anthropicResult(a.allocator, try acc.response());
             },
             .huggingface, .llama_cpp, .vercel, .mistral => |o| {
-                var result = GenerateResult.init(o.allocator);
-                errdefer result.deinit();
-                const ra = result.arena.allocator();
-
                 var req_arena = std.heap.ArenaAllocator.init(o.allocator);
                 defer req_arena.deinit();
                 const req_alloc = req_arena.allocator();
@@ -977,20 +852,15 @@ pub const Client = union(enum) {
                 const oai_messages = try messagesToOpenAIMessages(req_alloc, messages);
                 const tools = if (config.tools) |t| try mapOpenAITools(req_alloc, t) else null;
 
-                var accum = OpenAiAccum{ .alloc = ra, .on_text = on_text };
-                o.chatCompletionStream(model, oai_messages, mapOpenAICompletionConfig(config, tools), &accum, OpenAiAccum.onEvent) catch |err| switch (err) {
+                var acc = openai_mod.StreamAccumulator.init(req_alloc, on_text.context, on_text.onText);
+                o.chatCompletionStream(model, oai_messages, mapOpenAICompletionConfig(config, tools), &acc, openai_mod.StreamAccumulator.onEvent) catch |err| switch (err) {
                     error.OutOfMemory => return error.OutOfMemory,
                     else => return error.ApiError,
                 };
-                if (accum.err) |e| return e;
-                try accum.build(&result);
-                return result;
+                if (acc.err) |e| return e;
+                return openAiChatResult(o.allocator, try acc.response());
             },
             .gemini, .vertex => |g| {
-                var result = GenerateResult.init(g.allocator);
-                errdefer result.deinit();
-                const ra = result.arena.allocator();
-
                 var req_arena = std.heap.ArenaAllocator.init(g.allocator);
                 defer req_arena.deinit();
                 const req_alloc = req_arena.allocator();
@@ -1003,72 +873,22 @@ pub const Client = union(enum) {
                     null;
                 const tools = if (config.tools) |t| try mapGeminiTools(req_alloc, t) else null;
 
-                const State = struct {
-                    alloc: std.mem.Allocator,
-                    on_text: TextDeltaHook,
-                    text: std.ArrayListUnmanaged(u8) = .empty,
-                    calls: std.ArrayListUnmanaged(ToolCall) = .empty,
-                    finish_reason: FinishReason = .unknown,
-                    usage: Usage = .{},
-                    err: ?error{OutOfMemory} = null,
-
-                    fn onEvent(state: *@This(), chunk: gemini_types.GenerateContentResponse) void {
-                        state.handle(chunk) catch |e| {
-                            state.err = e;
-                        };
-                    }
-
-                    fn handle(state: *@This(), chunk: gemini_types.GenerateContentResponse) error{OutOfMemory}!void {
-                        if (chunk.text()) |txt| {
-                            if (txt.len > 0) {
-                                try state.text.appendSlice(state.alloc, txt);
-                                state.on_text.call(txt);
-                            }
-                        }
-                        const fr = mapGeminiFinishReason(chunk);
-                        if (fr != .unknown) state.finish_reason = fr;
-                        if (chunk.usageMetadata != null) state.usage = mapGeminiUsage(chunk);
-                        const candidates = chunk.candidates orelse return;
-                        if (candidates.len == 0) return;
-                        const content = candidates[0].content orelse return;
-                        for (content.parts) |p| {
-                            if (p.functionCall) |fc| {
-                                try state.calls.append(state.alloc, .{
-                                    .id = if (fc.id) |id| try state.alloc.dupe(u8, id) else "",
-                                    .name = if (fc.name) |n| try state.alloc.dupe(u8, n) else "",
-                                    .arguments = if (fc.args) |v| try json.dupeValue(state.alloc, v) else null,
-                                    .thought_signature = if (p.thoughtSignature) |ts| try state.alloc.dupe(u8, ts) else null,
-                                });
-                            }
-                        }
-                    }
-                };
-
-                var state = State{ .alloc = ra, .on_text = on_text };
+                var acc = gemini_mod.StreamAccumulator.init(req_alloc, on_text.context, on_text.onText);
                 g.generateContentStream(model, contents, mapGeminiGenerationConfig(model, config), .{
                     .systemInstruction = sys_instruction,
                     .tools = tools,
                     .toolConfig = mapToolChoiceToGemini(config.tool_choice),
-                }, &state, State.onEvent) catch |err| switch (err) {
+                }, &acc, gemini_mod.StreamAccumulator.onEvent) catch |err| switch (err) {
                     error.OutOfMemory => return error.OutOfMemory,
                     else => return error.ApiError,
                 };
-                if (state.err) |e| return e;
-
-                if (state.text.items.len > 0) result.text = state.text.items;
-                result.finish_reason = state.finish_reason;
-                result.usage = state.usage;
-                if (state.calls.items.len > 0) result.tool_calls = try state.calls.toOwnedSlice(ra);
-                return result;
+                if (acc.err) |e| return e;
+                return geminiResult(g.allocator, try acc.response());
             },
             // Native OpenAI streams via the Responses API: Chat Completions 400s
             // on function tools + reasoning for the gpt-5 family, and the buffered
             // path already uses Responses, so streaming stays consistent with it.
             .openai => |o| {
-                var result = GenerateResult.init(o.allocator);
-                errdefer result.deinit();
-                const ra = result.arena.allocator();
-
                 var req_arena = std.heap.ArenaAllocator.init(o.allocator);
                 defer req_arena.deinit();
                 const req_alloc = req_arena.allocator();
@@ -1076,7 +896,7 @@ pub const Client = union(enum) {
                 const input = try messagesToOpenAIResponsesInput(req_alloc, messages);
                 const tools = if (config.tools) |t| try mapOpenAIResponsesTools(req_alloc, t) else null;
 
-                var accum = OpenAiResponsesAccum{ .alloc = ra, .on_text = on_text };
+                var acc = openai_mod.ResponsesStreamAccumulator.init(req_alloc, on_text.context, on_text.onText);
                 o.createResponseStream(.{
                     .model = model,
                     .input = input,
@@ -1085,13 +905,12 @@ pub const Client = union(enum) {
                     .reasoning = if (config.effort) |tl| .{ .effort = mapEffortToOpenAI(tl) } else null,
                     .max_output_tokens = config.max_tokens,
                     .temperature = config.temperature,
-                }, &accum, OpenAiResponsesAccum.onEvent) catch |err| switch (err) {
+                }, &acc, openai_mod.ResponsesStreamAccumulator.onEvent) catch |err| switch (err) {
                     error.OutOfMemory => return error.OutOfMemory,
                     else => return error.ApiError,
                 };
-                if (accum.err) |e| return e;
-                try accum.build(&result);
-                return result;
+                if (acc.err) |e| return e;
+                return openAiResponsesResult(o.allocator, try acc.response());
             },
             // Ollama's native `/api/chat` is non-streaming; fall back to the
             // buffered call and emit the whole text in one delta so the caller
@@ -2310,240 +2129,130 @@ fn mapOllamaUsage(response: ollama_native.ChatResponse) Usage {
     };
 }
 
-/// Reassembles an Anthropic streamed message into a buffered `GenerateResult`.
-/// Fed one `StreamEvent` at a time via `onEvent`; `build` finalizes into a
-/// result. All accumulated storage lives in `alloc`, which must be the result
-/// arena so the wired-up slices outlive the accumulator.
-const AnthropicAccum = struct {
-    alloc: std.mem.Allocator,
-    on_text: Client.TextDeltaHook,
-    text: std.ArrayListUnmanaged(u8) = .empty,
-    blocks: std.ArrayListUnmanaged(Block) = .empty,
-    finish_reason: FinishReason = .unknown,
-    usage: Usage = .{},
-    err: ?error{OutOfMemory} = null,
-
-    const Block = struct {
-        index: i32,
-        id: []const u8,
-        name: []const u8,
-        json: std.ArrayListUnmanaged(u8) = .empty,
-    };
-
-    fn onEvent(self: *AnthropicAccum, event: anthropic_types.StreamEvent) void {
-        self.handle(event) catch |e| {
-            self.err = e;
-        };
-    }
-
-    fn handle(self: *AnthropicAccum, event: anthropic_types.StreamEvent) error{OutOfMemory}!void {
-        const et = event.type orelse return;
-        if (std.mem.eql(u8, et, "content_block_start")) {
-            const cb = event.content_block orelse return;
-            const ct = cb.type orelse return;
-            if (std.mem.eql(u8, ct, "tool_use")) {
-                try self.blocks.append(self.alloc, .{
-                    .index = event.index orelse 0,
-                    .id = if (cb.id) |id| try self.alloc.dupe(u8, id) else "",
-                    .name = if (cb.name) |n| try self.alloc.dupe(u8, n) else "",
-                });
-            }
-        } else if (std.mem.eql(u8, et, "content_block_delta")) {
-            const d = event.delta orelse return;
-            const dt = d.type orelse return;
-            if (std.mem.eql(u8, dt, "text_delta")) {
-                if (d.text) |txt| {
-                    try self.text.appendSlice(self.alloc, txt);
-                    self.on_text.call(txt);
+/// Map a Gemini `GenerateContentResponse` (buffered or stream-reassembled) into
+/// the unified `GenerateResult`. Shared by the buffered and streaming arms.
+fn geminiResult(alloc: std.mem.Allocator, response: gemini_types.GenerateContentResponse) Client.Error!GenerateResult {
+    var result = GenerateResult.init(alloc);
+    errdefer result.deinit();
+    const ra = result.arena.allocator();
+    if (response.text()) |t| result.text = try ra.dupe(u8, t);
+    result.finish_reason = mapGeminiFinishReason(response);
+    result.usage = mapGeminiUsage(response);
+    if (response.candidates) |candidates| {
+        if (candidates.len > 0) {
+            if (candidates[0].content) |content| {
+                var tool_calls: std.ArrayList(ToolCall) = .empty;
+                for (content.parts) |p| {
+                    const fc = p.functionCall orelse continue;
+                    try tool_calls.append(ra, .{
+                        .id = if (fc.id) |id| try ra.dupe(u8, id) else "",
+                        .name = if (fc.name) |n| try ra.dupe(u8, n) else "",
+                        .arguments = if (fc.args) |v| try json.dupeValue(ra, v) else null,
+                        .thought_signature = if (p.thoughtSignature) |ts| try ra.dupe(u8, ts) else null,
+                    });
                 }
-            } else if (std.mem.eql(u8, dt, "input_json_delta")) {
-                if (d.partial_json) |pj| {
-                    const idx = event.index orelse return;
-                    for (self.blocks.items) |*b| {
-                        if (b.index == idx) {
-                            try b.json.appendSlice(self.alloc, pj);
-                            break;
-                        }
-                    }
-                }
-            }
-        } else if (std.mem.eql(u8, et, "message_start")) {
-            if (event.message) |m| self.usage = convertAnthropicUsage(m.usage);
-        } else if (std.mem.eql(u8, et, "message_delta")) {
-            if (event.delta) |d| {
-                if (d.stop_reason) |sr| self.finish_reason = mapAnthropicStopReason(sr);
-            }
-            // message_delta reports the cumulative output count; input/cache
-            // counts stay as message_start reported them.
-            if (event.usage) |u| {
-                if (u.output_tokens) |ot| self.usage.completion_tokens = ot;
+                if (tool_calls.items.len > 0) result.tool_calls = try tool_calls.toOwnedSlice(ra);
             }
         }
     }
+    return result;
+}
 
-    fn build(self: *AnthropicAccum, result: *GenerateResult) error{OutOfMemory}!void {
-        if (self.text.items.len > 0) result.text = self.text.items;
-        result.finish_reason = self.finish_reason;
-        result.usage = self.usage;
-        if (self.usage.prompt_tokens != null and self.usage.completion_tokens != null) {
-            result.usage.total_tokens = self.usage.prompt_tokens.? + self.usage.completion_tokens.?;
-        }
-        if (self.blocks.items.len == 0) return;
-        const ra = result.arena.allocator();
+/// Map an Anthropic `MessageResponse` (buffered or stream-reassembled) into the
+/// unified `GenerateResult`. Shared by the buffered and streaming arms so both
+/// extract text/usage/tool_use identically.
+fn anthropicResult(alloc: std.mem.Allocator, response: anthropic_types.MessageResponse) Client.Error!GenerateResult {
+    var result = GenerateResult.init(alloc);
+    errdefer result.deinit();
+    const ra = result.arena.allocator();
+    if (response.text()) |t| result.text = try ra.dupe(u8, t);
+    result.finish_reason = mapAnthropicFinishReason(response);
+    result.usage = mapAnthropicUsage(response);
+    if (response.content) |blocks| {
         var tool_calls: std.ArrayList(ToolCall) = .empty;
-        for (self.blocks.items) |b| {
-            const args_val: ?std.json.Value = if (b.json.items.len > 0)
-                (std.json.parseFromSliceLeaky(std.json.Value, ra, b.json.items, .{}) catch null)
+        for (blocks) |block| {
+            const t = block.type orelse continue;
+            if (!std.mem.eql(u8, t, "tool_use")) continue;
+            try tool_calls.append(ra, .{
+                .id = if (block.id) |id| try ra.dupe(u8, id) else "",
+                .name = if (block.name) |n| try ra.dupe(u8, n) else "",
+                .arguments = if (block.input) |v| try json.dupeValue(ra, v) else null,
+            });
+        }
+        if (tool_calls.items.len > 0) result.tool_calls = try tool_calls.toOwnedSlice(ra);
+    }
+    return result;
+}
+
+/// Map an OpenAI-compatible `ChatCompletionResponse` (buffered or
+/// stream-reassembled) into the unified `GenerateResult`. Shared by the buffered
+/// and streaming arms of the Chat Completions providers.
+fn openAiChatResult(alloc: std.mem.Allocator, response: openai_types.ChatCompletionResponse) Client.Error!GenerateResult {
+    var result = GenerateResult.init(alloc);
+    errdefer result.deinit();
+    const ga = result.arena.allocator();
+    if (response.text()) |t| {
+        if (t.len > 0) result.text = try ga.dupe(u8, t);
+    }
+    result.finish_reason = mapOpenAIFinishReason(response);
+    result.usage = mapOpenAIUsage(response);
+
+    extract: {
+        const choices = response.choices orelse break :extract;
+        if (choices.len == 0) break :extract;
+        const msg = choices[0].message orelse break :extract;
+        const calls = msg.tool_calls orelse break :extract;
+
+        var tool_calls: std.ArrayList(ToolCall) = .empty;
+        for (calls) |call| {
+            const f = call.function orelse continue;
+            // Chat Completions returns arguments as a JSON string.
+            const args_val: ?std.json.Value = if (f.arguments) |a|
+                (std.json.parseFromSliceLeaky(std.json.Value, ga, a, .{}) catch null)
             else
                 null;
-            try tool_calls.append(ra, .{ .id = b.id, .name = b.name, .arguments = args_val });
+            try tool_calls.append(ga, .{
+                .id = if (call.id) |id| try ga.dupe(u8, id) else "",
+                .name = if (f.name) |n| try ga.dupe(u8, n) else "",
+                .arguments = args_val,
+            });
         }
-        result.tool_calls = try tool_calls.toOwnedSlice(ra);
+        if (tool_calls.items.len > 0) result.tool_calls = try tool_calls.toOwnedSlice(ga);
     }
-};
+    return result;
+}
 
-/// Reassembles an OpenAI-compatible streamed chat completion into a buffered
-/// `GenerateResult`, correlating tool-call argument fragments by their delta
-/// index. See `AnthropicAccum` for the `alloc` lifetime contract.
-const OpenAiAccum = struct {
-    alloc: std.mem.Allocator,
-    on_text: Client.TextDeltaHook,
-    text: std.ArrayListUnmanaged(u8) = .empty,
-    calls: std.ArrayListUnmanaged(Call) = .empty,
-    finish_reason: FinishReason = .unknown,
-    usage: Usage = .{},
-    err: ?error{OutOfMemory} = null,
-
-    const Call = struct {
-        index: i32,
-        id: std.ArrayListUnmanaged(u8) = .empty,
-        name: std.ArrayListUnmanaged(u8) = .empty,
-        args: std.ArrayListUnmanaged(u8) = .empty,
-    };
-
-    fn onEvent(self: *OpenAiAccum, chunk: openai_types.ChatCompletionResponse) void {
-        self.handle(chunk) catch |e| {
-            self.err = e;
-        };
+/// Map an OpenAI `ResponsesResponse` (buffered or stream-reassembled) into the
+/// unified `GenerateResult`. Shared by the buffered and streaming `.openai` arms.
+fn openAiResponsesResult(alloc: std.mem.Allocator, response: openai_types.ResponsesResponse) Client.Error!GenerateResult {
+    var result = GenerateResult.init(alloc);
+    errdefer result.deinit();
+    const ga = result.arena.allocator();
+    if (response.text()) |t| {
+        if (t.len > 0) result.text = try ga.dupe(u8, t);
     }
+    result.finish_reason = mapOpenAIResponsesFinishReason(response);
+    result.usage = mapOpenAIResponsesUsage(response);
 
-    fn slot(self: *OpenAiAccum, idx: i32) error{OutOfMemory}!*Call {
-        for (self.calls.items) |*c| {
-            if (c.index == idx) return c;
-        }
-        try self.calls.append(self.alloc, .{ .index = idx });
-        return &self.calls.items[self.calls.items.len - 1];
-    }
-
-    fn handle(self: *OpenAiAccum, chunk: openai_types.ChatCompletionResponse) error{OutOfMemory}!void {
-        // The final `include_usage` chunk carries usage with no choices.
-        if (chunk.usage != null) self.usage = mapOpenAIUsage(chunk);
-        const choices = chunk.choices orelse return;
-        if (choices.len == 0) return;
-        const c0 = choices[0];
-        if (c0.finish_reason != null) self.finish_reason = mapOpenAIFinishReason(chunk);
-        const delta = c0.delta orelse return;
-        if (delta.content) |txt| {
-            if (txt.len > 0) {
-                try self.text.appendSlice(self.alloc, txt);
-                self.on_text.call(txt);
-            }
-        }
-        if (delta.tool_calls) |tcs| {
-            for (tcs, 0..) |tc, i| {
-                const call = try self.slot(tc.index orelse @intCast(i));
-                if (tc.id) |id| {
-                    call.id.clearRetainingCapacity();
-                    try call.id.appendSlice(self.alloc, id);
-                }
-                if (tc.function) |f| {
-                    if (f.name) |n| {
-                        call.name.clearRetainingCapacity();
-                        try call.name.appendSlice(self.alloc, n);
-                    }
-                    if (f.arguments) |args| try call.args.appendSlice(self.alloc, args);
-                }
-            }
-        }
-    }
-
-    fn build(self: *OpenAiAccum, result: *GenerateResult) error{OutOfMemory}!void {
-        if (self.text.items.len > 0) result.text = self.text.items;
-        result.finish_reason = self.finish_reason;
-        result.usage = self.usage;
-        if (self.calls.items.len == 0) return;
-        const ra = result.arena.allocator();
+    if (response.output) |items| {
         var tool_calls: std.ArrayList(ToolCall) = .empty;
-        for (self.calls.items) |c| {
-            // Chat Completions delivers arguments as a JSON string.
-            const args_val: ?std.json.Value = if (c.args.items.len > 0)
-                (std.json.parseFromSliceLeaky(std.json.Value, ra, c.args.items, .{}) catch null)
+        for (items) |item| {
+            const item_type = item.type orelse continue;
+            if (!std.mem.eql(u8, item_type, "function_call")) continue;
+            const args_val: ?std.json.Value = if (item.arguments) |a|
+                (std.json.parseFromSliceLeaky(std.json.Value, ga, a, .{}) catch null)
             else
                 null;
-            try tool_calls.append(ra, .{ .id = c.id.items, .name = c.name.items, .arguments = args_val });
+            try tool_calls.append(ga, .{
+                .id = if (item.call_id) |id| try ga.dupe(u8, id) else "",
+                .name = if (item.name) |n| try ga.dupe(u8, n) else "",
+                .arguments = args_val,
+            });
         }
-        result.tool_calls = try tool_calls.toOwnedSlice(ra);
+        if (tool_calls.items.len > 0) result.tool_calls = try tool_calls.toOwnedSlice(ga);
     }
-};
-
-/// Reassembles an OpenAI Responses-API stream into a buffered `GenerateResult`.
-/// Text arrives as `output_text.delta` events; each `output_item.done` carries a
-/// complete `function_call` item (full arguments, no fragment reassembly); the
-/// terminal `response.completed`/`incomplete` event carries usage and status.
-/// See `AnthropicAccum` for the `alloc` lifetime contract.
-const OpenAiResponsesAccum = struct {
-    alloc: std.mem.Allocator,
-    on_text: Client.TextDeltaHook,
-    text: std.ArrayListUnmanaged(u8) = .empty,
-    calls: std.ArrayListUnmanaged(ToolCall) = .empty,
-    finish_reason: FinishReason = .unknown,
-    usage: Usage = .{},
-    err: ?error{OutOfMemory} = null,
-
-    fn onEvent(self: *OpenAiResponsesAccum, event: openai_types.ResponseStreamEvent) void {
-        self.handle(event) catch |e| {
-            self.err = e;
-        };
-    }
-
-    fn handle(self: *OpenAiResponsesAccum, event: openai_types.ResponseStreamEvent) error{OutOfMemory}!void {
-        const t = event.type orelse return;
-        if (std.mem.eql(u8, t, "response.output_text.delta")) {
-            if (event.delta) |d| {
-                if (d.len > 0) {
-                    try self.text.appendSlice(self.alloc, d);
-                    self.on_text.call(d);
-                }
-            }
-        } else if (std.mem.eql(u8, t, "response.output_item.done")) {
-            const item = event.item orelse return;
-            const it = item.type orelse return;
-            if (std.mem.eql(u8, it, "function_call")) {
-                const args_val: ?std.json.Value = if (item.arguments) |a|
-                    (std.json.parseFromSliceLeaky(std.json.Value, self.alloc, a, .{}) catch null)
-                else
-                    null;
-                try self.calls.append(self.alloc, .{
-                    .id = if (item.call_id) |id| try self.alloc.dupe(u8, id) else "",
-                    .name = if (item.name) |n| try self.alloc.dupe(u8, n) else "",
-                    .arguments = args_val,
-                });
-            }
-        } else if (std.mem.eql(u8, t, "response.completed") or std.mem.eql(u8, t, "response.incomplete")) {
-            if (event.response) |r| {
-                self.usage = mapOpenAIResponsesUsage(r);
-                self.finish_reason = mapOpenAIResponsesFinishReason(r);
-            }
-        }
-    }
-
-    fn build(self: *OpenAiResponsesAccum, result: *GenerateResult) error{OutOfMemory}!void {
-        if (self.text.items.len > 0) result.text = self.text.items;
-        result.finish_reason = self.finish_reason;
-        result.usage = self.usage;
-        if (self.calls.items.len > 0) result.tool_calls = try self.calls.toOwnedSlice(result.arena.allocator());
-    }
-};
+    return result;
+}
 
 fn mapAnthropicStopReason(reason: anthropic_types.StopReason) FinishReason {
     return switch (reason) {
@@ -2737,129 +2446,4 @@ test "mapEffortToAnthropic pairs adaptive thinking with effort and headroom" {
 
 test "mapEffortToAnthropic respects caller-supplied max_tokens when already large" {
     try std.testing.expectEqual(@as(i32, 64000), mapEffortToAnthropic(.medium, 64000).max_tokens);
-}
-
-const StreamProbe = struct {
-    count: usize = 0,
-    text: std.ArrayListUnmanaged(u8) = .empty,
-
-    fn cb(ptr: *anyopaque, delta: []const u8) void {
-        const self: *StreamProbe = @ptrCast(@alignCast(ptr));
-        self.count += 1;
-        self.text.appendSlice(std.testing.allocator, delta) catch {};
-    }
-
-    fn hook(self: *StreamProbe) Client.TextDeltaHook {
-        return .{ .context = self, .onText = cb };
-    }
-
-    fn deinit(self: *StreamProbe) void {
-        self.text.deinit(std.testing.allocator);
-    }
-};
-
-test "AnthropicAccum reassembles text and a tool call from a stream" {
-    var probe = StreamProbe{};
-    defer probe.deinit();
-
-    var result = GenerateResult.init(std.testing.allocator);
-    defer result.deinit();
-
-    var accum = AnthropicAccum{ .alloc = result.arena.allocator(), .on_text = probe.hook() };
-    const events = [_]anthropic_types.StreamEvent{
-        .{ .type = "message_start", .message = .{ .usage = .{ .input_tokens = 10, .output_tokens = 1 } } },
-        .{ .type = "content_block_start", .index = 0, .content_block = .{ .type = "text" } },
-        .{ .type = "content_block_delta", .index = 0, .delta = .{ .type = "text_delta", .text = "Let me " } },
-        .{ .type = "content_block_delta", .index = 0, .delta = .{ .type = "text_delta", .text = "search." } },
-        .{ .type = "content_block_start", .index = 1, .content_block = .{ .type = "tool_use", .id = "toolu_1", .name = "search" } },
-        .{ .type = "content_block_delta", .index = 1, .delta = .{ .type = "input_json_delta", .partial_json = "{\"q\":" } },
-        .{ .type = "content_block_delta", .index = 1, .delta = .{ .type = "input_json_delta", .partial_json = "\"cats\"}" } },
-        .{ .type = "content_block_stop", .index = 1 },
-        .{ .type = "message_delta", .delta = .{ .stop_reason = .tool_use }, .usage = .{ .output_tokens = 25 } },
-        .{ .type = "message_stop" },
-    };
-    for (events) |ev| accum.onEvent(ev);
-    try std.testing.expect(accum.err == null);
-    try accum.build(&result);
-
-    try std.testing.expectEqualStrings("Let me search.", result.text.?);
-    try std.testing.expectEqual(@as(usize, 2), probe.count);
-    try std.testing.expectEqualStrings("Let me search.", probe.text.items);
-    try std.testing.expectEqual(FinishReason.tool_call, result.finish_reason);
-    try std.testing.expectEqual(@as(?i32, 10), result.usage.prompt_tokens);
-    try std.testing.expectEqual(@as(?i32, 25), result.usage.completion_tokens);
-    try std.testing.expectEqual(@as(?i32, 35), result.usage.total_tokens);
-
-    const calls = result.tool_calls.?;
-    try std.testing.expectEqual(@as(usize, 1), calls.len);
-    try std.testing.expectEqualStrings("toolu_1", calls[0].id);
-    try std.testing.expectEqualStrings("search", calls[0].name);
-    try std.testing.expectEqualStrings("cats", calls[0].arguments.?.object.get("q").?.string);
-}
-
-test "OpenAiAccum reassembles text and correlates tool-call fragments by index" {
-    var probe = StreamProbe{};
-    defer probe.deinit();
-
-    var result = GenerateResult.init(std.testing.allocator);
-    defer result.deinit();
-
-    var accum = OpenAiAccum{ .alloc = result.arena.allocator(), .on_text = probe.hook() };
-    const chunks = [_]openai_types.ChatCompletionResponse{
-        .{ .choices = &.{.{ .index = 0, .delta = .{ .content = "Hel" } }} },
-        .{ .choices = &.{.{ .index = 0, .delta = .{ .content = "lo" } }} },
-        .{ .choices = &.{.{ .index = 0, .delta = .{ .tool_calls = &.{.{ .index = 0, .id = "call_1", .type = "function", .function = .{ .name = "search", .arguments = "" } }} } }} },
-        .{ .choices = &.{.{ .index = 0, .delta = .{ .tool_calls = &.{.{ .index = 0, .function = .{ .arguments = "{\"q\":" } }} } }} },
-        .{ .choices = &.{.{ .index = 0, .delta = .{ .tool_calls = &.{.{ .index = 0, .function = .{ .arguments = "\"dogs\"}" } }} } }} },
-        .{ .choices = &.{.{ .index = 0, .delta = .{}, .finish_reason = .tool_calls }} },
-        .{ .choices = &.{}, .usage = .{ .prompt_tokens = 5, .completion_tokens = 7, .total_tokens = 12 } },
-    };
-    for (chunks) |c| accum.onEvent(c);
-    try std.testing.expect(accum.err == null);
-    try accum.build(&result);
-
-    try std.testing.expectEqualStrings("Hello", result.text.?);
-    try std.testing.expectEqual(@as(usize, 2), probe.count);
-    try std.testing.expectEqual(FinishReason.tool_call, result.finish_reason);
-    try std.testing.expectEqual(@as(?i32, 7), result.usage.completion_tokens);
-
-    const calls = result.tool_calls.?;
-    try std.testing.expectEqual(@as(usize, 1), calls.len);
-    try std.testing.expectEqualStrings("call_1", calls[0].id);
-    try std.testing.expectEqualStrings("search", calls[0].name);
-    try std.testing.expectEqualStrings("dogs", calls[0].arguments.?.object.get("q").?.string);
-}
-
-test "OpenAiResponsesAccum reassembles text and a completed function-call item" {
-    var probe = StreamProbe{};
-    defer probe.deinit();
-
-    var result = GenerateResult.init(std.testing.allocator);
-    defer result.deinit();
-
-    var accum = OpenAiResponsesAccum{ .alloc = result.arena.allocator(), .on_text = probe.hook() };
-    const events = [_]openai_types.ResponseStreamEvent{
-        .{ .type = "response.output_text.delta", .delta = "Search" },
-        .{ .type = "response.output_text.delta", .delta = "ing." },
-        .{ .type = "response.output_item.done", .item = .{ .type = "function_call", .call_id = "call_9", .name = "search", .arguments = "{\"q\":\"birds\"}" } },
-        .{ .type = "response.completed", .response = .{
-            .status = "completed",
-            .output = &.{.{ .type = "function_call", .call_id = "call_9", .name = "search" }},
-            .usage = .{ .input_tokens = 8, .output_tokens = 4, .total_tokens = 12 },
-        } },
-    };
-    for (events) |ev| accum.onEvent(ev);
-    try std.testing.expect(accum.err == null);
-    try accum.build(&result);
-
-    try std.testing.expectEqualStrings("Searching.", result.text.?);
-    try std.testing.expectEqual(@as(usize, 2), probe.count);
-    try std.testing.expectEqual(FinishReason.tool_call, result.finish_reason);
-    try std.testing.expectEqual(@as(?i32, 4), result.usage.completion_tokens);
-
-    const calls = result.tool_calls.?;
-    try std.testing.expectEqual(@as(usize, 1), calls.len);
-    try std.testing.expectEqualStrings("call_9", calls[0].id);
-    try std.testing.expectEqualStrings("search", calls[0].name);
-    try std.testing.expectEqualStrings("birds", calls[0].arguments.?.object.get("q").?.string);
 }

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -916,6 +916,196 @@ pub const Client = union(enum) {
         }
     }
 
+    /// Streaming counterpart of `generateContent`: reassembles the full
+    /// response — text and tool-use blocks — into a buffered `GenerateResult`
+    /// while forwarding each text delta to `on_text` as it arrives. Used by
+    /// `runTools` when a `TextDeltaHook` is configured. The returned struct is
+    /// shape-identical to `generateContent`'s, so the tool loop is unaffected.
+    fn generateContentStreamAccumulate(
+        self: Client,
+        model: []const u8,
+        messages: []const Message,
+        config: GenerationConfig,
+        on_text: TextDeltaHook,
+    ) Error!GenerateResult {
+        switch (self) {
+            .anthropic => |a| {
+                var result = GenerateResult.init(a.allocator);
+                errdefer result.deinit();
+                const ra = result.arena.allocator();
+
+                var req_arena = std.heap.ArenaAllocator.init(a.allocator);
+                defer req_arena.deinit();
+                const req_alloc = req_arena.allocator();
+
+                const system_text = try extractSystemText(req_alloc, messages);
+                const ant_messages = try messagesToAnthropicMessages(req_alloc, messages);
+                const system_blocks: ?[]const anthropic_types.TextBlock = if (system_text) |sys|
+                    @as([]const anthropic_types.TextBlock, &.{.{ .text = sys }})
+                else
+                    null;
+                const tools = if (config.tools) |t| try mapAnthropicTools(req_alloc, t) else null;
+                const reasoning = mapEffortToAnthropic(config.effort, config.max_tokens orelse 4096);
+
+                var accum = AnthropicAccum{ .alloc = ra, .on_text = on_text };
+                a.createMessageStream(model, ant_messages, reasoning.max_tokens, .{
+                    .system = system_blocks,
+                    .temperature = config.temperature,
+                    .top_p = config.top_p,
+                    .stop_sequences = config.stop,
+                    .tools = tools,
+                    .tool_choice = mapToolChoiceToAnthropic(config.tool_choice),
+                    .thinking = reasoning.thinking,
+                    .output_config = reasoning.output_config,
+                }, &accum, AnthropicAccum.onEvent) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    else => return error.ApiError,
+                };
+                if (accum.err) |e| return e;
+                try accum.build(&result);
+                return result;
+            },
+            .huggingface, .llama_cpp, .vercel, .mistral => |o| {
+                var result = GenerateResult.init(o.allocator);
+                errdefer result.deinit();
+                const ra = result.arena.allocator();
+
+                var req_arena = std.heap.ArenaAllocator.init(o.allocator);
+                defer req_arena.deinit();
+                const req_alloc = req_arena.allocator();
+
+                const oai_messages = try messagesToOpenAIMessages(req_alloc, messages);
+                const tools = if (config.tools) |t| try mapOpenAITools(req_alloc, t) else null;
+
+                var accum = OpenAiAccum{ .alloc = ra, .on_text = on_text };
+                o.chatCompletionStream(model, oai_messages, mapOpenAICompletionConfig(config, tools), &accum, OpenAiAccum.onEvent) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    else => return error.ApiError,
+                };
+                if (accum.err) |e| return e;
+                try accum.build(&result);
+                return result;
+            },
+            .gemini, .vertex => |g| {
+                var result = GenerateResult.init(g.allocator);
+                errdefer result.deinit();
+                const ra = result.arena.allocator();
+
+                var req_arena = std.heap.ArenaAllocator.init(g.allocator);
+                defer req_arena.deinit();
+                const req_alloc = req_arena.allocator();
+
+                const separated = try separateSystemMessages(req_alloc, messages);
+                const contents = separated.contents;
+                const sys_instruction: ?gemini_types.Content = if (separated.system_text) |sys|
+                    gemini_types.Content{ .parts = @as([]const gemini_types.Part, &.{.{ .text = sys }}) }
+                else
+                    null;
+                const tools = if (config.tools) |t| try mapGeminiTools(req_alloc, t) else null;
+
+                const State = struct {
+                    alloc: std.mem.Allocator,
+                    on_text: TextDeltaHook,
+                    text: std.ArrayListUnmanaged(u8) = .empty,
+                    calls: std.ArrayListUnmanaged(ToolCall) = .empty,
+                    finish_reason: FinishReason = .unknown,
+                    usage: Usage = .{},
+                    err: ?error{OutOfMemory} = null,
+
+                    fn onEvent(state: *@This(), chunk: gemini_types.GenerateContentResponse) void {
+                        state.handle(chunk) catch |e| {
+                            state.err = e;
+                        };
+                    }
+
+                    fn handle(state: *@This(), chunk: gemini_types.GenerateContentResponse) error{OutOfMemory}!void {
+                        if (chunk.text()) |txt| {
+                            if (txt.len > 0) {
+                                try state.text.appendSlice(state.alloc, txt);
+                                state.on_text.call(txt);
+                            }
+                        }
+                        const fr = mapGeminiFinishReason(chunk);
+                        if (fr != .unknown) state.finish_reason = fr;
+                        if (chunk.usageMetadata != null) state.usage = mapGeminiUsage(chunk);
+                        const candidates = chunk.candidates orelse return;
+                        if (candidates.len == 0) return;
+                        const content = candidates[0].content orelse return;
+                        for (content.parts) |p| {
+                            if (p.functionCall) |fc| {
+                                try state.calls.append(state.alloc, .{
+                                    .id = if (fc.id) |id| try state.alloc.dupe(u8, id) else "",
+                                    .name = if (fc.name) |n| try state.alloc.dupe(u8, n) else "",
+                                    .arguments = if (fc.args) |v| try json.dupeValue(state.alloc, v) else null,
+                                    .thought_signature = if (p.thoughtSignature) |ts| try state.alloc.dupe(u8, ts) else null,
+                                });
+                            }
+                        }
+                    }
+                };
+
+                var state = State{ .alloc = ra, .on_text = on_text };
+                g.generateContentStream(model, contents, mapGeminiGenerationConfig(model, config), .{
+                    .systemInstruction = sys_instruction,
+                    .tools = tools,
+                    .toolConfig = mapToolChoiceToGemini(config.tool_choice),
+                }, &state, State.onEvent) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    else => return error.ApiError,
+                };
+                if (state.err) |e| return e;
+
+                if (state.text.items.len > 0) result.text = state.text.items;
+                result.finish_reason = state.finish_reason;
+                result.usage = state.usage;
+                if (state.calls.items.len > 0) result.tool_calls = try state.calls.toOwnedSlice(ra);
+                return result;
+            },
+            // Native OpenAI streams via the Responses API: Chat Completions 400s
+            // on function tools + reasoning for the gpt-5 family, and the buffered
+            // path already uses Responses, so streaming stays consistent with it.
+            .openai => |o| {
+                var result = GenerateResult.init(o.allocator);
+                errdefer result.deinit();
+                const ra = result.arena.allocator();
+
+                var req_arena = std.heap.ArenaAllocator.init(o.allocator);
+                defer req_arena.deinit();
+                const req_alloc = req_arena.allocator();
+
+                const input = try messagesToOpenAIResponsesInput(req_alloc, messages);
+                const tools = if (config.tools) |t| try mapOpenAIResponsesTools(req_alloc, t) else null;
+
+                var accum = OpenAiResponsesAccum{ .alloc = ra, .on_text = on_text };
+                o.createResponseStream(.{
+                    .model = model,
+                    .input = input,
+                    .tools = tools,
+                    .tool_choice = mapToolChoiceToOpenAI(config.tool_choice),
+                    .reasoning = if (config.effort) |tl| .{ .effort = mapEffortToOpenAI(tl) } else null,
+                    .max_output_tokens = config.max_tokens,
+                    .temperature = config.temperature,
+                }, &accum, OpenAiResponsesAccum.onEvent) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    else => return error.ApiError,
+                };
+                if (accum.err) |e| return e;
+                try accum.build(&result);
+                return result;
+            },
+            // Ollama's native `/api/chat` is non-streaming; fall back to the
+            // buffered call and emit the whole text in one delta so the caller
+            // still sees it.
+            .ollama => {
+                const result = try self.generateContent(model, messages, config);
+                if (result.text) |t| {
+                    if (t.len > 0) on_text.call(t);
+                }
+                return result;
+            },
+        }
+    }
+
     /// Generate an embedding for a text string.
     pub fn embed(
         self: Client,
@@ -991,6 +1181,10 @@ pub const Client = union(enum) {
         /// HTTP request still runs to completion before the check fires
         /// (the loop owns iteration, not the HTTP layer).
         cancel: ?CancelHook = null,
+        /// When set, each turn streams the model response, forwarding text
+        /// deltas to this hook as they arrive while still accumulating tool
+        /// calls into the buffered per-turn result. Null runs the buffered path.
+        stream: ?TextDeltaHook = null,
 
         pub fn cancelRequested(self: RunToolsConfig) bool {
             return if (self.cancel) |c| c.check() else false;
@@ -1003,6 +1197,19 @@ pub const Client = union(enum) {
 
         pub fn check(self: CancelHook) bool {
             return self.checkFn(self.context);
+        }
+    };
+
+    /// Fired with each incremental assistant-text delta as it streams from the
+    /// model. When set on `RunToolsConfig.stream`, `runTools` drives a streaming
+    /// request per turn (reassembling tool calls internally) instead of the
+    /// buffered path; when null, behavior is unchanged.
+    pub const TextDeltaHook = struct {
+        context: *anyopaque,
+        onText: *const fn (context: *anyopaque, delta: []const u8) void,
+
+        pub fn call(self: TextDeltaHook, delta: []const u8) void {
+            self.onText(self.context, delta);
         }
     };
 
@@ -1062,15 +1269,27 @@ pub const Client = union(enum) {
                 cancelled = true;
                 break;
             }
-            var gen_result = try self.generateContent(model, messages.items, .{
+            const gen_config: GenerationConfig = .{
                 .tools = config.tools,
                 .max_tokens = config.max_tokens,
                 .tool_choice = config.tool_choice,
                 .temperature = config.temperature,
                 .effort = config.effort,
-            });
+            };
+            var gen_result = if (config.stream) |hook|
+                try self.generateContentStreamAccumulate(model, messages.items, gen_config, hook)
+            else
+                try self.generateContent(model, messages.items, gen_config);
             defer gen_result.deinit();
             total_usage.add(gen_result.usage);
+
+            // A streamed turn returns partial data on mid-stream cancel rather
+            // than erroring; catch it here so the loop stops instead of treating
+            // the fragment as a finished answer.
+            if (config.cancelRequested()) {
+                cancelled = true;
+                break;
+            }
 
             if (gen_result.tool_calls) |tool_calls| {
                 const duped_calls = try dupeToolCalls(data_alloc, tool_calls);
@@ -2091,6 +2310,241 @@ fn mapOllamaUsage(response: ollama_native.ChatResponse) Usage {
     };
 }
 
+/// Reassembles an Anthropic streamed message into a buffered `GenerateResult`.
+/// Fed one `StreamEvent` at a time via `onEvent`; `build` finalizes into a
+/// result. All accumulated storage lives in `alloc`, which must be the result
+/// arena so the wired-up slices outlive the accumulator.
+const AnthropicAccum = struct {
+    alloc: std.mem.Allocator,
+    on_text: Client.TextDeltaHook,
+    text: std.ArrayListUnmanaged(u8) = .empty,
+    blocks: std.ArrayListUnmanaged(Block) = .empty,
+    finish_reason: FinishReason = .unknown,
+    usage: Usage = .{},
+    err: ?error{OutOfMemory} = null,
+
+    const Block = struct {
+        index: i32,
+        id: []const u8,
+        name: []const u8,
+        json: std.ArrayListUnmanaged(u8) = .empty,
+    };
+
+    fn onEvent(self: *AnthropicAccum, event: anthropic_types.StreamEvent) void {
+        self.handle(event) catch |e| {
+            self.err = e;
+        };
+    }
+
+    fn handle(self: *AnthropicAccum, event: anthropic_types.StreamEvent) error{OutOfMemory}!void {
+        const et = event.type orelse return;
+        if (std.mem.eql(u8, et, "content_block_start")) {
+            const cb = event.content_block orelse return;
+            const ct = cb.type orelse return;
+            if (std.mem.eql(u8, ct, "tool_use")) {
+                try self.blocks.append(self.alloc, .{
+                    .index = event.index orelse 0,
+                    .id = if (cb.id) |id| try self.alloc.dupe(u8, id) else "",
+                    .name = if (cb.name) |n| try self.alloc.dupe(u8, n) else "",
+                });
+            }
+        } else if (std.mem.eql(u8, et, "content_block_delta")) {
+            const d = event.delta orelse return;
+            const dt = d.type orelse return;
+            if (std.mem.eql(u8, dt, "text_delta")) {
+                if (d.text) |txt| {
+                    try self.text.appendSlice(self.alloc, txt);
+                    self.on_text.call(txt);
+                }
+            } else if (std.mem.eql(u8, dt, "input_json_delta")) {
+                if (d.partial_json) |pj| {
+                    const idx = event.index orelse return;
+                    for (self.blocks.items) |*b| {
+                        if (b.index == idx) {
+                            try b.json.appendSlice(self.alloc, pj);
+                            break;
+                        }
+                    }
+                }
+            }
+        } else if (std.mem.eql(u8, et, "message_start")) {
+            if (event.message) |m| self.usage = convertAnthropicUsage(m.usage);
+        } else if (std.mem.eql(u8, et, "message_delta")) {
+            if (event.delta) |d| {
+                if (d.stop_reason) |sr| self.finish_reason = mapAnthropicStopReason(sr);
+            }
+            // message_delta reports the cumulative output count; input/cache
+            // counts stay as message_start reported them.
+            if (event.usage) |u| {
+                if (u.output_tokens) |ot| self.usage.completion_tokens = ot;
+            }
+        }
+    }
+
+    fn build(self: *AnthropicAccum, result: *GenerateResult) error{OutOfMemory}!void {
+        if (self.text.items.len > 0) result.text = self.text.items;
+        result.finish_reason = self.finish_reason;
+        result.usage = self.usage;
+        if (self.usage.prompt_tokens != null and self.usage.completion_tokens != null) {
+            result.usage.total_tokens = self.usage.prompt_tokens.? + self.usage.completion_tokens.?;
+        }
+        if (self.blocks.items.len == 0) return;
+        const ra = result.arena.allocator();
+        var tool_calls: std.ArrayList(ToolCall) = .empty;
+        for (self.blocks.items) |b| {
+            const args_val: ?std.json.Value = if (b.json.items.len > 0)
+                (std.json.parseFromSliceLeaky(std.json.Value, ra, b.json.items, .{}) catch null)
+            else
+                null;
+            try tool_calls.append(ra, .{ .id = b.id, .name = b.name, .arguments = args_val });
+        }
+        result.tool_calls = try tool_calls.toOwnedSlice(ra);
+    }
+};
+
+/// Reassembles an OpenAI-compatible streamed chat completion into a buffered
+/// `GenerateResult`, correlating tool-call argument fragments by their delta
+/// index. See `AnthropicAccum` for the `alloc` lifetime contract.
+const OpenAiAccum = struct {
+    alloc: std.mem.Allocator,
+    on_text: Client.TextDeltaHook,
+    text: std.ArrayListUnmanaged(u8) = .empty,
+    calls: std.ArrayListUnmanaged(Call) = .empty,
+    finish_reason: FinishReason = .unknown,
+    usage: Usage = .{},
+    err: ?error{OutOfMemory} = null,
+
+    const Call = struct {
+        index: i32,
+        id: std.ArrayListUnmanaged(u8) = .empty,
+        name: std.ArrayListUnmanaged(u8) = .empty,
+        args: std.ArrayListUnmanaged(u8) = .empty,
+    };
+
+    fn onEvent(self: *OpenAiAccum, chunk: openai_types.ChatCompletionResponse) void {
+        self.handle(chunk) catch |e| {
+            self.err = e;
+        };
+    }
+
+    fn slot(self: *OpenAiAccum, idx: i32) error{OutOfMemory}!*Call {
+        for (self.calls.items) |*c| {
+            if (c.index == idx) return c;
+        }
+        try self.calls.append(self.alloc, .{ .index = idx });
+        return &self.calls.items[self.calls.items.len - 1];
+    }
+
+    fn handle(self: *OpenAiAccum, chunk: openai_types.ChatCompletionResponse) error{OutOfMemory}!void {
+        // The final `include_usage` chunk carries usage with no choices.
+        if (chunk.usage != null) self.usage = mapOpenAIUsage(chunk);
+        const choices = chunk.choices orelse return;
+        if (choices.len == 0) return;
+        const c0 = choices[0];
+        if (c0.finish_reason != null) self.finish_reason = mapOpenAIFinishReason(chunk);
+        const delta = c0.delta orelse return;
+        if (delta.content) |txt| {
+            if (txt.len > 0) {
+                try self.text.appendSlice(self.alloc, txt);
+                self.on_text.call(txt);
+            }
+        }
+        if (delta.tool_calls) |tcs| {
+            for (tcs, 0..) |tc, i| {
+                const call = try self.slot(tc.index orelse @intCast(i));
+                if (tc.id) |id| {
+                    call.id.clearRetainingCapacity();
+                    try call.id.appendSlice(self.alloc, id);
+                }
+                if (tc.function) |f| {
+                    if (f.name) |n| {
+                        call.name.clearRetainingCapacity();
+                        try call.name.appendSlice(self.alloc, n);
+                    }
+                    if (f.arguments) |args| try call.args.appendSlice(self.alloc, args);
+                }
+            }
+        }
+    }
+
+    fn build(self: *OpenAiAccum, result: *GenerateResult) error{OutOfMemory}!void {
+        if (self.text.items.len > 0) result.text = self.text.items;
+        result.finish_reason = self.finish_reason;
+        result.usage = self.usage;
+        if (self.calls.items.len == 0) return;
+        const ra = result.arena.allocator();
+        var tool_calls: std.ArrayList(ToolCall) = .empty;
+        for (self.calls.items) |c| {
+            // Chat Completions delivers arguments as a JSON string.
+            const args_val: ?std.json.Value = if (c.args.items.len > 0)
+                (std.json.parseFromSliceLeaky(std.json.Value, ra, c.args.items, .{}) catch null)
+            else
+                null;
+            try tool_calls.append(ra, .{ .id = c.id.items, .name = c.name.items, .arguments = args_val });
+        }
+        result.tool_calls = try tool_calls.toOwnedSlice(ra);
+    }
+};
+
+/// Reassembles an OpenAI Responses-API stream into a buffered `GenerateResult`.
+/// Text arrives as `output_text.delta` events; each `output_item.done` carries a
+/// complete `function_call` item (full arguments, no fragment reassembly); the
+/// terminal `response.completed`/`incomplete` event carries usage and status.
+/// See `AnthropicAccum` for the `alloc` lifetime contract.
+const OpenAiResponsesAccum = struct {
+    alloc: std.mem.Allocator,
+    on_text: Client.TextDeltaHook,
+    text: std.ArrayListUnmanaged(u8) = .empty,
+    calls: std.ArrayListUnmanaged(ToolCall) = .empty,
+    finish_reason: FinishReason = .unknown,
+    usage: Usage = .{},
+    err: ?error{OutOfMemory} = null,
+
+    fn onEvent(self: *OpenAiResponsesAccum, event: openai_types.ResponseStreamEvent) void {
+        self.handle(event) catch |e| {
+            self.err = e;
+        };
+    }
+
+    fn handle(self: *OpenAiResponsesAccum, event: openai_types.ResponseStreamEvent) error{OutOfMemory}!void {
+        const t = event.type orelse return;
+        if (std.mem.eql(u8, t, "response.output_text.delta")) {
+            if (event.delta) |d| {
+                if (d.len > 0) {
+                    try self.text.appendSlice(self.alloc, d);
+                    self.on_text.call(d);
+                }
+            }
+        } else if (std.mem.eql(u8, t, "response.output_item.done")) {
+            const item = event.item orelse return;
+            const it = item.type orelse return;
+            if (std.mem.eql(u8, it, "function_call")) {
+                const args_val: ?std.json.Value = if (item.arguments) |a|
+                    (std.json.parseFromSliceLeaky(std.json.Value, self.alloc, a, .{}) catch null)
+                else
+                    null;
+                try self.calls.append(self.alloc, .{
+                    .id = if (item.call_id) |id| try self.alloc.dupe(u8, id) else "",
+                    .name = if (item.name) |n| try self.alloc.dupe(u8, n) else "",
+                    .arguments = args_val,
+                });
+            }
+        } else if (std.mem.eql(u8, t, "response.completed") or std.mem.eql(u8, t, "response.incomplete")) {
+            if (event.response) |r| {
+                self.usage = mapOpenAIResponsesUsage(r);
+                self.finish_reason = mapOpenAIResponsesFinishReason(r);
+            }
+        }
+    }
+
+    fn build(self: *OpenAiResponsesAccum, result: *GenerateResult) error{OutOfMemory}!void {
+        if (self.text.items.len > 0) result.text = self.text.items;
+        result.finish_reason = self.finish_reason;
+        result.usage = self.usage;
+        if (self.calls.items.len > 0) result.tool_calls = try self.calls.toOwnedSlice(result.arena.allocator());
+    }
+};
+
 fn mapAnthropicStopReason(reason: anthropic_types.StopReason) FinishReason {
     return switch (reason) {
         .end_turn, .stop_sequence => .stop,
@@ -2283,4 +2737,129 @@ test "mapEffortToAnthropic pairs adaptive thinking with effort and headroom" {
 
 test "mapEffortToAnthropic respects caller-supplied max_tokens when already large" {
     try std.testing.expectEqual(@as(i32, 64000), mapEffortToAnthropic(.medium, 64000).max_tokens);
+}
+
+const StreamProbe = struct {
+    count: usize = 0,
+    text: std.ArrayListUnmanaged(u8) = .empty,
+
+    fn cb(ptr: *anyopaque, delta: []const u8) void {
+        const self: *StreamProbe = @ptrCast(@alignCast(ptr));
+        self.count += 1;
+        self.text.appendSlice(std.testing.allocator, delta) catch {};
+    }
+
+    fn hook(self: *StreamProbe) Client.TextDeltaHook {
+        return .{ .context = self, .onText = cb };
+    }
+
+    fn deinit(self: *StreamProbe) void {
+        self.text.deinit(std.testing.allocator);
+    }
+};
+
+test "AnthropicAccum reassembles text and a tool call from a stream" {
+    var probe = StreamProbe{};
+    defer probe.deinit();
+
+    var result = GenerateResult.init(std.testing.allocator);
+    defer result.deinit();
+
+    var accum = AnthropicAccum{ .alloc = result.arena.allocator(), .on_text = probe.hook() };
+    const events = [_]anthropic_types.StreamEvent{
+        .{ .type = "message_start", .message = .{ .usage = .{ .input_tokens = 10, .output_tokens = 1 } } },
+        .{ .type = "content_block_start", .index = 0, .content_block = .{ .type = "text" } },
+        .{ .type = "content_block_delta", .index = 0, .delta = .{ .type = "text_delta", .text = "Let me " } },
+        .{ .type = "content_block_delta", .index = 0, .delta = .{ .type = "text_delta", .text = "search." } },
+        .{ .type = "content_block_start", .index = 1, .content_block = .{ .type = "tool_use", .id = "toolu_1", .name = "search" } },
+        .{ .type = "content_block_delta", .index = 1, .delta = .{ .type = "input_json_delta", .partial_json = "{\"q\":" } },
+        .{ .type = "content_block_delta", .index = 1, .delta = .{ .type = "input_json_delta", .partial_json = "\"cats\"}" } },
+        .{ .type = "content_block_stop", .index = 1 },
+        .{ .type = "message_delta", .delta = .{ .stop_reason = .tool_use }, .usage = .{ .output_tokens = 25 } },
+        .{ .type = "message_stop" },
+    };
+    for (events) |ev| accum.onEvent(ev);
+    try std.testing.expect(accum.err == null);
+    try accum.build(&result);
+
+    try std.testing.expectEqualStrings("Let me search.", result.text.?);
+    try std.testing.expectEqual(@as(usize, 2), probe.count);
+    try std.testing.expectEqualStrings("Let me search.", probe.text.items);
+    try std.testing.expectEqual(FinishReason.tool_call, result.finish_reason);
+    try std.testing.expectEqual(@as(?i32, 10), result.usage.prompt_tokens);
+    try std.testing.expectEqual(@as(?i32, 25), result.usage.completion_tokens);
+    try std.testing.expectEqual(@as(?i32, 35), result.usage.total_tokens);
+
+    const calls = result.tool_calls.?;
+    try std.testing.expectEqual(@as(usize, 1), calls.len);
+    try std.testing.expectEqualStrings("toolu_1", calls[0].id);
+    try std.testing.expectEqualStrings("search", calls[0].name);
+    try std.testing.expectEqualStrings("cats", calls[0].arguments.?.object.get("q").?.string);
+}
+
+test "OpenAiAccum reassembles text and correlates tool-call fragments by index" {
+    var probe = StreamProbe{};
+    defer probe.deinit();
+
+    var result = GenerateResult.init(std.testing.allocator);
+    defer result.deinit();
+
+    var accum = OpenAiAccum{ .alloc = result.arena.allocator(), .on_text = probe.hook() };
+    const chunks = [_]openai_types.ChatCompletionResponse{
+        .{ .choices = &.{.{ .index = 0, .delta = .{ .content = "Hel" } }} },
+        .{ .choices = &.{.{ .index = 0, .delta = .{ .content = "lo" } }} },
+        .{ .choices = &.{.{ .index = 0, .delta = .{ .tool_calls = &.{.{ .index = 0, .id = "call_1", .type = "function", .function = .{ .name = "search", .arguments = "" } }} } }} },
+        .{ .choices = &.{.{ .index = 0, .delta = .{ .tool_calls = &.{.{ .index = 0, .function = .{ .arguments = "{\"q\":" } }} } }} },
+        .{ .choices = &.{.{ .index = 0, .delta = .{ .tool_calls = &.{.{ .index = 0, .function = .{ .arguments = "\"dogs\"}" } }} } }} },
+        .{ .choices = &.{.{ .index = 0, .delta = .{}, .finish_reason = .tool_calls }} },
+        .{ .choices = &.{}, .usage = .{ .prompt_tokens = 5, .completion_tokens = 7, .total_tokens = 12 } },
+    };
+    for (chunks) |c| accum.onEvent(c);
+    try std.testing.expect(accum.err == null);
+    try accum.build(&result);
+
+    try std.testing.expectEqualStrings("Hello", result.text.?);
+    try std.testing.expectEqual(@as(usize, 2), probe.count);
+    try std.testing.expectEqual(FinishReason.tool_call, result.finish_reason);
+    try std.testing.expectEqual(@as(?i32, 7), result.usage.completion_tokens);
+
+    const calls = result.tool_calls.?;
+    try std.testing.expectEqual(@as(usize, 1), calls.len);
+    try std.testing.expectEqualStrings("call_1", calls[0].id);
+    try std.testing.expectEqualStrings("search", calls[0].name);
+    try std.testing.expectEqualStrings("dogs", calls[0].arguments.?.object.get("q").?.string);
+}
+
+test "OpenAiResponsesAccum reassembles text and a completed function-call item" {
+    var probe = StreamProbe{};
+    defer probe.deinit();
+
+    var result = GenerateResult.init(std.testing.allocator);
+    defer result.deinit();
+
+    var accum = OpenAiResponsesAccum{ .alloc = result.arena.allocator(), .on_text = probe.hook() };
+    const events = [_]openai_types.ResponseStreamEvent{
+        .{ .type = "response.output_text.delta", .delta = "Search" },
+        .{ .type = "response.output_text.delta", .delta = "ing." },
+        .{ .type = "response.output_item.done", .item = .{ .type = "function_call", .call_id = "call_9", .name = "search", .arguments = "{\"q\":\"birds\"}" } },
+        .{ .type = "response.completed", .response = .{
+            .status = "completed",
+            .output = &.{.{ .type = "function_call", .call_id = "call_9", .name = "search" }},
+            .usage = .{ .input_tokens = 8, .output_tokens = 4, .total_tokens = 12 },
+        } },
+    };
+    for (events) |ev| accum.onEvent(ev);
+    try std.testing.expect(accum.err == null);
+    try accum.build(&result);
+
+    try std.testing.expectEqualStrings("Searching.", result.text.?);
+    try std.testing.expectEqual(@as(usize, 2), probe.count);
+    try std.testing.expectEqual(FinishReason.tool_call, result.finish_reason);
+    try std.testing.expectEqual(@as(?i32, 4), result.usage.completion_tokens);
+
+    const calls = result.tool_calls.?;
+    try std.testing.expectEqual(@as(usize, 1), calls.len);
+    try std.testing.expectEqualStrings("call_9", calls[0].id);
+    try std.testing.expectEqualStrings("search", calls[0].name);
+    try std.testing.expectEqualStrings("birds", calls[0].arguments.?.object.get("q").?.string);
 }


### PR DESCRIPTION
## What

Adds opt-in streaming to the agentic `runTools` loop so callers can render assistant text token-by-token as the model produces it, across every turn of the tool loop.

Streaming is **opt-in per call**: `runTools` streams only when the caller sets `RunToolsConfig.stream` (a `TextDeltaHook`). With no hook it takes the buffered `generateContent` path, byte-for-byte unchanged — so non-streaming consumers are unaffected.

## How

- **`RunToolsConfig.stream: ?TextDeltaHook`** — fires each incremental text delta while the tool loop still accumulates tool calls internally and returns the usual `RunToolsResult`.
- **`generateContentStreamAccumulate`** dispatches per provider, reassembling the SSE stream into that provider's **buffered response type**, then reusing the *same* buffered→unified mapping the non-streaming arms use.
- Each provider client owns its reassembly, depending only on its own types:
  - `anthropic`: `StreamAccumulator` → `MessageResponse`
  - `openai`: `StreamAccumulator` → `ChatCompletionResponse`; `ResponsesStreamAccumulator` → `ResponsesResponse`
  - `gemini`: `StreamAccumulator` → `GenerateContentResponse`
- `provider.zig` keeps four thin `*Result` helpers (`anthropicResult`, `openAiChatResult`, `openAiResponsesResult`, `geminiResult`) shared by the buffered and streaming arms — deletes the tool-call extraction that was previously duplicated.

### Fixes surfaced along the way (streaming clients were never exercised in prod)
- **gzip'd SSE**: the streaming clients read the raw body without decompressing, so a gzip'd response arrived as unparseable bytes → request `accept-encoding: identity` on all streaming requests.
- **Native OpenAI**: `gpt-5.x` rejects function tools + reasoning on `/chat/completions` (requires the Responses API). Added `createResponseStream` (Responses-API SSE) and route native OpenAI through it, consistent with its buffered path. Ollama stays a single-shot fallback (no native streaming).

## Tests

Each accumulator has a unit test in its provider module feeding a canned SSE event sequence and asserting the reassembled response (text concatenation + tool-call reassembly + usage). `zig build test`: 82/82 pass.

Verified end-to-end against Anthropic, OpenAI (Responses), and Gemini — plain-text and tool-using turns.