### PR TITLE
feat(search): add Brave Search client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zenai
 
-Zig client for AI APIs, supporting [Google Gemini](https://ai.google.dev/gemini-api/docs) (Developer API and [Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs)), [OpenAI](https://platform.openai.com/docs/api-reference), and [Anthropic](https://docs.anthropic.com/en/docs/about-claude/models). OpenAI-compatible endpoints — [Ollama](https://github.com/ollama/ollama/blob/main/docs/openai.md), [Hugging Face Inference](https://huggingface.co/docs/inference-providers/index), and [llama.cpp](https://github.com/ggml-org/llama.cpp/tree/master/tools/server) (`llama-server`) — are supported through the OpenAI client. Ported from the official [Go Gen AI SDK](https://github.com/googleapis/go-genai), [openai-go](https://github.com/openai/openai-go), and [anthropic-sdk-go](https://github.com/anthropics/anthropic-sdk-go). Also ships an `agent infrastructure` namespace under `zenai.search` — currently [Tavily](https://docs.tavily.com/), with room for sibling providers.
+Zig client for AI APIs, supporting [Google Gemini](https://ai.google.dev/gemini-api/docs) (Developer API and [Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs)), [OpenAI](https://platform.openai.com/docs/api-reference), and [Anthropic](https://docs.anthropic.com/en/docs/about-claude/models). OpenAI-compatible endpoints — [Ollama](https://github.com/ollama/ollama/blob/main/docs/openai.md), [Hugging Face Inference](https://huggingface.co/docs/inference-providers/index), and [llama.cpp](https://github.com/ggml-org/llama.cpp/tree/master/tools/server) (`llama-server`) — are supported through the OpenAI client. Ported from the official [Go Gen AI SDK](https://github.com/googleapis/go-genai), [openai-go](https://github.com/openai/openai-go), and [anthropic-sdk-go](https://github.com/anthropics/anthropic-sdk-go). Also ships an `agent infrastructure` namespace under `zenai.search` — currently [Tavily](https://docs.tavily.com/) and [Brave Search](https://brave.com/search/api/), with room for sibling providers.
 
 <img width="1024" height="1024" alt="Meditating panda with incense smoke" src="https://github.com/user-attachments/assets/b9c82960-05ec-4aa1-b171-092ee2126551" />
 
@@ -302,6 +302,32 @@ for (response.value.results) |r| {
 }
 ```
 
+## Brave (search)
+
+Brave Search is a web search API over Brave's independent index, returning JSON sections of `{title, url, description}` results. Set your API key ([get one here](https://api-dashboard.search.brave.com/)):
+
+```bash
+export BRAVE_API_KEY='BSA...'
+```
+
+```zig
+const zenai = @import("zenai");
+
+const api_key = std.posix.getenv("BRAVE_API_KEY") orelse return error.MissingApiKey;
+var client = zenai.search.brave.Client.init(allocator, api_key, .{});
+defer client.deinit();
+
+// text_decorations=false strips <strong> highlight markup from descriptions.
+var response = try client.search("what is zig", .{ .count = 5, .text_decorations = false });
+defer response.deinit();
+
+if (response.value.web) |web| {
+    for (web.results) |r| {
+        std.debug.print("{s} — {s}\n", .{ r.title, r.url });
+    }
+}
+```
+
 ## Provider Abstraction
 
 Use `zenai.provider.Client` to write provider-agnostic code. Swap providers by changing one line:
@@ -391,6 +417,7 @@ switch (ai) {
 
 **Search providers:**
 - Tavily (`zenai.search.tavily`) — JSON search API with optional synthesized answers, domain include/exclude, news/general topic, time-range filtering
+- Brave (`zenai.search.brave`) — independent-index web search with country/language targeting, safesearch, freshness and section filtering, extra snippets
 
 **Provider abstraction:**
 - Unified text generation, streaming, and embeddings

--- a/src/root.zig
+++ b/src/root.zig
@@ -40,12 +40,16 @@ pub const llama_cpp = openai;
 pub const vercel = openai;
 pub const mistral = openai;
 
-/// Search providers — separate namespace from the LLM clients above. Tavily
-/// is the first; Brave/Serper/Google CSE could land as siblings here.
+/// Search providers — separate namespace from the LLM clients above.
+/// Serper/Google CSE could land as siblings here.
 pub const search = struct {
     pub const tavily = struct {
         pub const Client = @import("search/tavily/Client.zig");
         pub const types = @import("search/tavily/types.zig");
+    };
+    pub const brave = struct {
+        pub const Client = @import("search/brave/Client.zig");
+        pub const types = @import("search/brave/types.zig");
     };
 };
 
@@ -67,6 +71,8 @@ test {
     _ = anthropic.types;
     _ = search.tavily.Client;
     _ = search.tavily.types;
+    _ = search.brave.Client;
+    _ = search.brave.types;
     _ = provider;
     _ = retry;
     _ = json;

--- a/src/search/brave/Client.zig
+++ b/src/search/brave/Client.zig
@@ -1,0 +1,176 @@
+//! Brave Web Search API client.
+//! https://api-dashboard.search.brave.com/app/documentation/web-search/get-started
+//!
+//! An independent-index web search API: a GET with the query in the URL comes
+//! back as JSON sections (`web.results`, `news.results`, …) of
+//! `{title, url, description}` hits. Descriptions carry `<strong>` highlight
+//! markup unless `text_decorations` is set to false.
+
+const std = @import("std");
+const types = @import("types.zig");
+const http = @import("../../http.zig");
+const retry = @import("../../retry.zig");
+
+pub const RetryPolicy = retry.RetryPolicy;
+
+const SearchOptions = types.SearchOptions;
+const SearchResponse = types.SearchResponse;
+
+const Client = @This();
+
+allocator: std.mem.Allocator,
+api_key: []const u8,
+base_url: []const u8,
+http_client: std.http.Client,
+retry_policy: RetryPolicy,
+last_error_status: ?u10 = null,
+last_error_body: ?[]const u8 = null,
+
+pub const InitOptions = struct {
+    base_url: []const u8 = "https://api.search.brave.com",
+    retry_policy: RetryPolicy = .{},
+};
+
+pub fn init(allocator: std.mem.Allocator, api_key: []const u8, options: InitOptions) Client {
+    return .{
+        .allocator = allocator,
+        .api_key = api_key,
+        .base_url = options.base_url,
+        .http_client = .{ .allocator = allocator },
+        .retry_policy = options.retry_policy,
+    };
+}
+
+pub fn deinit(self: *Client) void {
+    self.http_client.deinit();
+    if (self.last_error_body) |b| self.allocator.free(b);
+}
+
+pub const Response = http.Response;
+
+pub const ApiError = error{
+    ApiError,
+    MissingApiKey,
+    EmptyResponse,
+} || std.http.Client.FetchError || std.json.ParseError(std.json.Scanner) || std.mem.Allocator.Error || std.Uri.ParseError;
+
+pub fn setErrorDetail(self: *Client, status_code: u10, body: []const u8) void {
+    self.last_error_status = status_code;
+    if (self.last_error_body) |old| self.allocator.free(old);
+    self.last_error_body = if (body.len == 0) null else self.allocator.dupe(u8, body) catch null;
+}
+
+/// Run a search. Caller owns the returned `Response` and must call `deinit()`.
+pub fn search(
+    self: *Client,
+    query: []const u8,
+    options: SearchOptions,
+) ApiError!Response(SearchResponse) {
+    if (self.api_key.len == 0) return error.MissingApiKey;
+
+    const url = try buildSearchUrl(self.allocator, self.base_url, query, options);
+    defer self.allocator.free(url);
+
+    const extra_headers = [_]std.http.Header{
+        .{ .name = "X-Subscription-Token", .value = self.api_key },
+        .{ .name = "Accept", .value = "application/json" },
+    };
+
+    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, .{
+        .location = .{ .url = url },
+        .method = .GET,
+        .extra_headers = &extra_headers,
+    }, SearchResponse, self);
+}
+
+fn buildSearchUrl(
+    allocator: std.mem.Allocator,
+    base_url: []const u8,
+    query: []const u8,
+    options: SearchOptions,
+) std.mem.Allocator.Error![]u8 {
+    var buf: std.Io.Writer.Allocating = .init(allocator);
+    errdefer buf.deinit();
+    writeSearchUrl(&buf.writer, base_url, query, options) catch return error.OutOfMemory;
+    return buf.toOwnedSlice();
+}
+
+fn writeSearchUrl(
+    w: *std.Io.Writer,
+    base_url: []const u8,
+    query: []const u8,
+    options: SearchOptions,
+) std.Io.Writer.Error!void {
+    try w.print("{s}/res/v1/web/search?q=", .{base_url});
+    try percentEncode(w, query);
+    if (options.count) |v| try w.print("&count={d}", .{v});
+    if (options.offset) |v| try w.print("&offset={d}", .{v});
+    if (options.country) |v| {
+        try w.writeAll("&country=");
+        try percentEncode(w, v);
+    }
+    if (options.search_lang) |v| {
+        try w.writeAll("&search_lang=");
+        try percentEncode(w, v);
+    }
+    if (options.safesearch) |v| try w.print("&safesearch={s}", .{@tagName(v)});
+    if (options.freshness) |v| {
+        try w.writeAll("&freshness=");
+        try percentEncode(w, v);
+    }
+    if (options.result_filter) |v| {
+        try w.writeAll("&result_filter=");
+        try percentEncode(w, v);
+    }
+    if (options.extra_snippets) |v| try w.print("&extra_snippets={s}", .{boolStr(v)});
+    if (options.text_decorations) |v| try w.print("&text_decorations={s}", .{boolStr(v)});
+    if (options.spellcheck) |v| try w.print("&spellcheck={s}", .{boolStr(v)});
+}
+
+fn boolStr(v: bool) []const u8 {
+    return if (v) "true" else "false";
+}
+
+// `std.Uri.Component.formatQuery` is not strict enough here: RFC 3986 query
+// production permits `&`, `=`, and `+` raw, which would corrupt parameter
+// framing. Encode everything outside the unreserved set instead.
+fn percentEncode(w: *std.Io.Writer, raw: []const u8) std.Io.Writer.Error!void {
+    try std.Uri.Component.percentEncode(w, raw, isUnreserved);
+}
+
+fn isUnreserved(c: u8) bool {
+    return switch (c) {
+        'A'...'Z', 'a'...'z', '0'...'9', '-', '.', '_', '~' => true,
+        else => false,
+    };
+}
+
+test "search rejects empty api key" {
+    var client = init(std.testing.allocator, "", .{});
+    defer client.deinit();
+    try std.testing.expectError(error.MissingApiKey, client.search("anything", .{}));
+}
+
+test "buildSearchUrl percent-encodes the query" {
+    const url = try buildSearchUrl(std.testing.allocator, "https://api.search.brave.com", "fish & chips = +1?", .{});
+    defer std.testing.allocator.free(url);
+    try std.testing.expectEqualStrings(
+        "https://api.search.brave.com/res/v1/web/search?q=fish%20%26%20chips%20%3D%20%2B1%3F",
+        url,
+    );
+}
+
+test "buildSearchUrl appends set options" {
+    const url = try buildSearchUrl(std.testing.allocator, "http://localhost", "zig", .{
+        .count = 10,
+        .country = "US",
+        .safesearch = .off,
+        .result_filter = "web,news",
+        .text_decorations = false,
+    });
+    defer std.testing.allocator.free(url);
+    try std.testing.expectEqualStrings(
+        "http://localhost/res/v1/web/search?q=zig&count=10&country=US&safesearch=off&result_filter=web%2Cnews&text_decorations=false",
+        url,
+    );
+}

--- a/src/search/brave/types.zig
+++ b/src/search/brave/types.zig
@@ -1,0 +1,86 @@
+//! Brave Web Search API request/response shapes.
+//! https://api-dashboard.search.brave.com/app/documentation/web-search/get-started
+
+const std = @import("std");
+
+pub const SafeSearch = enum {
+    off,
+    moderate,
+    strict,
+};
+
+/// One search hit — the same shape serves `web.results` and `news.results`.
+pub const Result = struct {
+    title: []const u8 = "",
+    url: []const u8 = "",
+    description: []const u8 = "",
+    age: ?[]const u8 = null,
+    extra_snippets: ?[]const []const u8 = null,
+};
+
+pub const WebResults = struct {
+    results: []const Result = &.{},
+};
+
+pub const NewsResults = struct {
+    results: []const Result = &.{},
+};
+
+pub const QueryInfo = struct {
+    original: []const u8 = "",
+    more_results_available: ?bool = null,
+};
+
+pub const SearchResponse = struct {
+    query: ?QueryInfo = null,
+    web: ?WebResults = null,
+    news: ?NewsResults = null,
+};
+
+pub const SearchOptions = struct {
+    /// Results per page, max 20 (provider default 20).
+    count: ?u8 = null,
+    /// Zero-based page offset, max 9.
+    offset: ?u8 = null,
+    /// Two-letter country code, e.g. "US".
+    country: ?[]const u8 = null,
+    /// ISO 639-1 language code for result content.
+    search_lang: ?[]const u8 = null,
+    safesearch: ?SafeSearch = null,
+    /// `pd`/`pw`/`pm`/`py`, or a `YYYY-MM-DDtoYYYY-MM-DD` range.
+    freshness: ?[]const u8 = null,
+    /// Comma-separated result sections to include, e.g. "web,news".
+    result_filter: ?[]const u8 = null,
+    /// Up to 5 additional excerpts per result.
+    extra_snippets: ?bool = null,
+    /// Highlight markup (`<strong>`) in descriptions; set false for plain text.
+    text_decorations: ?bool = null,
+    spellcheck: ?bool = null,
+};
+
+test "SearchResponse parses Brave fixture" {
+    const fixture =
+        \\{
+        \\  "type": "search",
+        \\  "query": {"original": "capital of france", "more_results_available": true, "spellcheck_off": false},
+        \\  "mixed": {"type": "mixed", "main": []},
+        \\  "web": {
+        \\    "type": "search",
+        \\    "results": [
+        \\      {"title": "Paris - Wikipedia", "url": "https://en.wikipedia.org/wiki/Paris", "description": "Paris is the capital.", "age": "January 2, 2026", "profile": {"name": "Wikipedia"}},
+        \\      {"title": "France", "url": "https://example.org/fr", "description": "Country.", "extra_snippets": ["Paris is its capital."]}
+        \\    ]
+        \\  }
+        \\}
+    ;
+    const parsed = try std.json.parseFromSlice(SearchResponse, std.testing.allocator, fixture, .{ .ignore_unknown_fields = true });
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("capital of france", parsed.value.query.?.original);
+    try std.testing.expectEqual(true, parsed.value.query.?.more_results_available.?);
+    const results = parsed.value.web.?.results;
+    try std.testing.expectEqual(@as(usize, 2), results.len);
+    try std.testing.expectEqualStrings("Paris - Wikipedia", results[0].title);
+    try std.testing.expectEqualStrings("January 2, 2026", results[0].age.?);
+    try std.testing.expectEqualStrings("Paris is its capital.", results[1].extra_snippets.?[0]);
+    try std.testing.expect(parsed.value.news == null);
+}


### PR DESCRIPTION
## Summary

Adds `zenai.search.brave` as a sibling of the Tavily client — a thin wrapper over the [Brave Web Search API](https://api-dashboard.search.brave.com/app/documentation/web-search/get-started).

Unlike Tavily's POST-JSON API, Brave is a `GET /res/v1/web/search` with the query in the URL and `X-Subscription-Token` auth. The client:

- builds the URL via a testable `buildSearchUrl`, percent-encoding everything outside the RFC 3986 unreserved set (`std.Uri.Component.formatQuery` is not strict enough here — the query production permits raw `&`/`=`/`+`, which would corrupt parameter framing)
- exposes a curated `SearchOptions` subset (`count`, `offset`, `country`, `search_lang`, `safesearch`, `freshness`, `result_filter`, `extra_snippets`, `text_decorations`, `spellcheck`), all-null optionals like the Tavily client
- parses the `query`/`web`/`news` response sections leniently (`ignore_unknown_fields`), sharing one `Result` shape for web and news hits
- reuses `http.fetchJsonWithRetry`, so 429s (Brave's free tier is ~1 req/s) retry with backoff and error bodies land in `last_error_status`/`last_error_body`

Consumed by the browser's `search` tool fallback chain and the new `/searchEngine` REPL metacommand (separate PR in the browser repo).

## Testing

- `zig build test`: 88/88, including new tests for URL building/encoding, a response fixture matching the documented schema, and the empty-api-key guard.
- No live API call — no key on hand yet. Verified against the real endpoint with a dummy token that our exact URL shapes are accepted (the only error returned is `422 SUBSCRIPTION_TOKEN_INVALID`) and that error bodies are structured JSON our error path captures. Boolean `true`/`false` params and `result_filter` comma lists match Brave's own documented cURL examples.

Once a key is available, the smoke test is:
```sh
curl -H "X-Subscription-Token: $BRAVE_API_KEY" 'https://api.search.brave.com/res/v1/web/search?q=zig&count=3&text_decorations=false'
```