### PR TITLE
feat: support custom OpenAI compatible APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,10 +379,10 @@ const ai: zenai.provider.Client = .{ .gemini = &gemini_client };
 // Or any OpenAI-compatible server (vLLM, LiteLLM, Together, Groq, etc.).
 // Auto-detected by `provider.Client.init` when OPENAI_BASE_URL is set; the
 // key comes from OPENAI_API_KEY. With the raw client, pass `.base_url`:
-// var custom_client = zenai.generic_openai.Client.init(io, allocator, api_key, .{
+// var custom_client = zenai.openai_compatible.Client.init(io, allocator, api_key, .{
 //     .base_url = "https://my-custom-server.com/v1",
 // });
-// const ai: zenai.provider.Client = .{ .generic_openai = &custom_client };
+// const ai: zenai.provider.Client = .{ .openai_compatible = &custom_client };
 
 var result = try ai.generateContent("gemini-2.5-flash", &.{
     .{ .role = .user, .content = "What is Zig?" },

--- a/README.md
+++ b/README.md
@@ -376,6 +376,14 @@ const ai: zenai.provider.Client = .{ .gemini = &gemini_client };
 // });
 // const ai: zenai.provider.Client = .{ .llama_cpp = &llama_client };
 
+// Or any OpenAI-compatible server (vLLM, LiteLLM, Together, Groq, etc.).
+// Auto-detected when OPENAI_BASE_URL is set; the key comes from
+// OPENAI_API_KEY:
+// export OPENAI_BASE_URL=https://my-custom-server.com/v1
+// export OPENAI_API_KEY=my-key
+// var custom_client = zenai.generic_openai.Client.init(allocator, api_key, .{});
+// const ai: zenai.provider.Client = .{ .generic_openai = &custom_client };
+
 var result = try ai.generateContent("gemini-2.5-flash", &.{
     .{ .role = .user, .content = "What is Zig?" },
 }, .{});
@@ -429,7 +437,7 @@ switch (ai) {
 
 **Provider abstraction:**
 - Unified text generation, streaming, and embeddings
-- OpenAI-compatible backends: Ollama, Hugging Face, and llama.cpp (`llama-server`)
+- OpenAI-compatible backends: Ollama, Hugging Face, llama.cpp (`llama-server`), and any custom server via `OPENAI_BASE_URL`
 - `lastError()` to surface the status and message behind a failed request
 - Escape hatches to provider-specific APIs
 

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -1251,7 +1251,13 @@ pub fn envApiKey(environ: std.process.Environ, tag: Tag) ?[:0]const u8 {
     }
     return switch (tag) {
         .anthropic => environ.getPosix("ANTHROPIC_API_KEY"),
-        .openai => environ.getPosix("OPENAI_API_KEY"),
+        // OPENAI_BASE_URL gates OPENAI_API_KEY between `.openai` and
+        // `.generic_openai` so exactly one of them can ever detect it,
+        // mirroring the `.gemini`/`.vertex` split on GOOGLE_API_KEY.
+        .openai => if (environ.getPosix("OPENAI_BASE_URL") == null)
+            environ.getPosix("OPENAI_API_KEY")
+        else
+            null,
         .generic_openai => if (environ.getPosix("OPENAI_BASE_URL") != null)
             environ.getPosix("OPENAI_API_KEY")
         else
@@ -1568,6 +1574,23 @@ test "generic_openai: no static preset, env-gated key detection" {
     try std.testing.expect(openAiPreset(.generic_openai) == null);
     // Without OPENAI_BASE_URL the key must not be detected — that's `.openai`.
     try std.testing.expect(envApiKey(.empty, .generic_openai) == null);
+}
+
+test "openai/generic_openai: OPENAI_BASE_URL splits key detection" {
+    // Environ.PosixBlock is not the block representation on Windows.
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+    const with_url: std.process.Environ = .{ .block = .{ .slice = &[_:null]?[*:0]const u8{
+        "OPENAI_BASE_URL=http://localhost:8000/v1",
+        "OPENAI_API_KEY=sk-test",
+    } } };
+    try std.testing.expect(envApiKey(with_url, .openai) == null);
+    try std.testing.expectEqualStrings("sk-test", envApiKey(with_url, .generic_openai).?);
+
+    const without_url: std.process.Environ = .{ .block = .{ .slice = &[_:null]?[*:0]const u8{
+        "OPENAI_API_KEY=sk-test",
+    } } };
+    try std.testing.expectEqualStrings("sk-test", envApiKey(without_url, .openai).?);
+    try std.testing.expect(envApiKey(without_url, .generic_openai) == null);
 }
 
 test "generic_openai: envVarName and defaultModel" {

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -430,6 +430,9 @@ pub const Client = union(enum) {
     ollama: *openai_mod,
     huggingface: *openai_mod,
     llama_cpp: *openai_mod,
+    /// Any OpenAI-compatible server configured via `OPENAI_BASE_URL`
+    /// + `OPENAI_API_KEY`. Auto-detected when `OPENAI_BASE_URL` is set.
+    generic_openai: *openai_mod,
     vercel: *openai_mod,
     mistral: *openai_mod,
 
@@ -596,7 +599,7 @@ pub const Client = union(enum) {
             },
             // Hugging Face speaks OpenAI-compatible Chat Completions, not the
             // Responses API the `.openai` arm uses — so it gets its own arm.
-            .huggingface, .llama_cpp, .vercel, .mistral => |o| {
+            .huggingface, .llama_cpp, .generic_openai, .vercel, .mistral => |o| {
                 var req_arena = std.heap.ArenaAllocator.init(o.allocator);
                 defer req_arena.deinit();
                 const req_alloc = req_arena.allocator();
@@ -681,7 +684,7 @@ pub const Client = union(enum) {
                     .toolConfig = mapToolChoiceToGemini(config.tool_choice),
                 }, .{ .user_ctx = context, .user_cb = callback, .alloc = g.allocator }, &Wrapper.wrap);
             },
-            .openai, .huggingface, .llama_cpp, .vercel, .mistral => |o| {
+            .openai, .huggingface, .llama_cpp, .generic_openai, .vercel, .mistral => |o| {
                 var req_arena = std.heap.ArenaAllocator.init(o.allocator);
                 defer req_arena.deinit();
                 const req_alloc = req_arena.allocator();
@@ -797,7 +800,7 @@ pub const Client = union(enum) {
                 if (acc.err) |e| return e;
                 return anthropicResult(a.allocator, try acc.response());
             },
-            .huggingface, .llama_cpp, .vercel, .mistral => |o| {
+            .huggingface, .generic_openai, .llama_cpp, .vercel, .mistral => |o| {
                 var req_arena = std.heap.ArenaAllocator.init(o.allocator);
                 defer req_arena.deinit();
                 const req_alloc = req_arena.allocator();
@@ -903,7 +906,7 @@ pub const Client = union(enum) {
                 }
                 return result;
             },
-            .openai, .ollama, .huggingface, .llama_cpp, .vercel, .mistral => |o| {
+            .openai, .ollama, .huggingface, .generic_openai, .llama_cpp, .vercel, .mistral => |o| {
                 var response = try o.embedText(model, text);
                 defer response.deinit();
                 var result = EmbedResult.init(o.allocator);
@@ -1179,6 +1182,14 @@ fn openAiPreset(tag: Tag) ?OpenAiPreset {
     return switch (tag) {
         .ollama => .{ .base_url = "http://localhost:11434/v1", .placeholder_key = "ollama", .default_model = "qwen3.5:latest", .local = true },
         .huggingface => .{ .base_url = "https://router.huggingface.co/v1", .env_var = "HF_TOKEN", .default_model = "Qwen/Qwen3.5-122B-A10B" },
+        .generic_openai => blk: {
+            const base_url = std.posix.getenv("OPENAI_BASE_URL") orelse return null;
+            break :blk .{
+                .base_url = base_url,
+                .env_var = "OPENAI_API_KEY",
+                .default_model = "",
+            };
+        },
         // Empty default: the served model is whatever `llama-server` loaded.
         .llama_cpp => .{ .base_url = "http://localhost:8080/v1", .placeholder_key = "llama.cpp", .default_model = "", .local = true },
         .vercel => .{ .base_url = "https://ai-gateway.vercel.sh/v1", .env_var = "AI_GATEWAY_API_KEY", .default_model = "openai/gpt-5.5" },
@@ -1205,6 +1216,10 @@ pub fn envApiKey(environ: std.process.Environ, tag: Tag) ?[:0]const u8 {
     return switch (tag) {
         .anthropic => environ.getPosix("ANTHROPIC_API_KEY"),
         .openai => environ.getPosix("OPENAI_API_KEY"),
+        .generic_openai => if (std.posix.getenv("OPENAI_BASE_URL") != null)
+            std.posix.getenv("OPENAI_API_KEY")
+        else
+            null,
         .gemini => if (useVertex(environ))
             null
         else
@@ -1231,6 +1246,7 @@ pub fn envVarName(tag: Tag) []const u8 {
         .openai => "OPENAI_API_KEY",
         .gemini => "GOOGLE_API_KEY/GEMINI_API_KEY",
         .vertex => "VERTEX_API_KEY/GOOGLE_API_KEY",
+        .generic_openai => "OPENAI_API_KEY",
         else => unreachable,
     };
 }
@@ -1246,6 +1262,7 @@ pub fn defaultModel(tag: Tag) []const u8 {
         .anthropic => "claude-sonnet-5",
         .openai => "gpt-5.5",
         .gemini, .vertex => "gemini-3.6-flash",
+        .generic_openai => "",
         else => unreachable,
     };
 }
@@ -1281,6 +1298,14 @@ pub const default_candidates: []const Tag = blk: {
     var arr: [all.len]Tag = undefined;
     var n: usize = 0;
     for (all) |t| {
+        // generic_openai is always a candidate; the runtime envApiKey gates
+        // detection on OPENAI_BASE_URL being set, so it's only auto-detected
+        // when the user has explicitly configured a custom server.
+        if (t == .generic_openai) {
+            arr[n] = t;
+            n += 1;
+            continue;
+        }
         if (openAiPreset(t)) |p| if (p.local) continue;
         arr[n] = t;
         n += 1;
@@ -1503,6 +1528,29 @@ test "vercel/mistral: real-key cloud presets, auto-detectable" {
         try std.testing.expect(t != .ollama and t != .llama_cpp);
     }
     try std.testing.expect(saw_vercel and saw_mistral);
+}
+
+test "generic_openai: no preset when OPENAI_BASE_URL is unset" {
+    // Without the env var, there's no valid base URL — the preset must be null
+    // so generic_openai never silently falls back to api.openai.com.
+    try std.testing.expect(openAiPreset(.generic_openai) == null);
+    try std.testing.expect(envApiKey(.generic_openai) == null);
+}
+
+test "generic_openai: envVarName and defaultModel" {
+    // These don't need the env var set — they're compile-time constants.
+    try std.testing.expectEqualStrings("OPENAI_API_KEY", envVarName(.generic_openai));
+    try std.testing.expectEqualStrings("", defaultModel(.generic_openai));
+}
+
+test "generic_openai: present in default_candidates (runtime-gated)" {
+    // generic_openai is always in the candidate list; runtime envApiKey
+    // gates actual detection on OPENAI_BASE_URL being set.
+    var found = false;
+    for (default_candidates) |t| {
+        if (t == .generic_openai) found = true;
+    }
+    try std.testing.expect(found);
 }
 
 test "defaultEffort: none for Mistral, unset elsewhere" {

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -433,7 +433,7 @@ pub const Client = union(enum) {
     llama_cpp: *openai_mod,
     /// Any OpenAI-compatible server configured via `OPENAI_BASE_URL`
     /// + `OPENAI_API_KEY`. Auto-detected when `OPENAI_BASE_URL` is set.
-    generic_openai: *openai_mod,
+    openai_compatible: *openai_mod,
     vercel: *openai_mod,
     mistral: *openai_mod,
     codex: *codex_mod,
@@ -465,7 +465,7 @@ pub const Client = union(enum) {
         /// other providers.
         location: ?[]const u8 = null,
         /// Environment for the `.vertex` project/location fallbacks above and
-        /// the `.generic_openai` OPENAI_BASE_URL fallback. The default
+        /// the `.openai_compatible` OPENAI_BASE_URL fallback. The default
         /// `.empty` disables env detection.
         environ: std.process.Environ = .empty,
         /// ChatGPT account id for `.codex` (`ChatGPT-Account-Id` header),
@@ -486,7 +486,7 @@ pub const Client = union(enum) {
                 errdefer allocator.destroy(client);
                 const base_url: ?[:0]const u8 = options.base_url orelse switch (tag) {
                     // Never fall through to api.openai.com.
-                    .generic_openai => options.environ.getPosix("OPENAI_BASE_URL") orelse return error.MissingBaseUrl,
+                    .openai_compatible => options.environ.getPosix("OPENAI_BASE_URL") orelse return error.MissingBaseUrl,
                     else => if (openAiPreset(tag)) |p| p.base_url else null,
                 };
                 var impl_opts: Impl.InitOptions = .{ .retry_policy = options.retry_policy };
@@ -616,7 +616,7 @@ pub const Client = union(enum) {
             },
             // Hugging Face speaks OpenAI-compatible Chat Completions, not the
             // Responses API the `.openai` arm uses — so it gets its own arm.
-            .huggingface, .llama_cpp, .generic_openai, .vercel, .mistral => |o| {
+            .huggingface, .llama_cpp, .openai_compatible, .vercel, .mistral => |o| {
                 var req_arena = std.heap.ArenaAllocator.init(o.allocator);
                 defer req_arena.deinit();
                 const req_alloc = req_arena.allocator();
@@ -704,7 +704,7 @@ pub const Client = union(enum) {
                     .toolConfig = mapToolChoiceToGemini(config.tool_choice),
                 }, .{ .user_ctx = context, .user_cb = callback, .alloc = g.allocator }, &Wrapper.wrap);
             },
-            .openai, .huggingface, .llama_cpp, .generic_openai, .vercel, .mistral => |o| {
+            .openai, .huggingface, .llama_cpp, .openai_compatible, .vercel, .mistral => |o| {
                 var req_arena = std.heap.ArenaAllocator.init(o.allocator);
                 defer req_arena.deinit();
                 const req_alloc = req_arena.allocator();
@@ -826,7 +826,7 @@ pub const Client = union(enum) {
                 if (acc.err) |e| return e;
                 return anthropicResult(a.allocator, try acc.response());
             },
-            .huggingface, .generic_openai, .llama_cpp, .vercel, .mistral => |o| {
+            .huggingface, .openai_compatible, .llama_cpp, .vercel, .mistral => |o| {
                 var req_arena = std.heap.ArenaAllocator.init(o.allocator);
                 defer req_arena.deinit();
                 const req_alloc = req_arena.allocator();
@@ -948,7 +948,7 @@ pub const Client = union(enum) {
                 }
                 return result;
             },
-            .openai, .ollama, .huggingface, .generic_openai, .llama_cpp, .vercel, .mistral => |o| {
+            .openai, .ollama, .huggingface, .openai_compatible, .llama_cpp, .vercel, .mistral => |o| {
                 var response = try o.embedText(model, text);
                 defer response.deinit();
                 var result = EmbedResult.init(o.allocator);
@@ -1225,7 +1225,7 @@ fn openAiPreset(tag: Tag) ?OpenAiPreset {
         .ollama => .{ .base_url = "http://localhost:11434/v1", .placeholder_key = "ollama", .default_model = "qwen3.5:latest", .local = true },
         .huggingface => .{ .base_url = "https://router.huggingface.co/v1", .env_var = "HF_TOKEN", .default_model = "Qwen/Qwen3.5-122B-A10B" },
         // No static preset: the base URL comes from OPENAI_BASE_URL.
-        .generic_openai => null,
+        .openai_compatible => null,
         // Empty default: the served model is whatever `llama-server` loaded.
         .llama_cpp => .{ .base_url = "http://localhost:8080/v1", .placeholder_key = "llama.cpp", .default_model = "", .local = true },
         .vercel => .{ .base_url = "https://ai-gateway.vercel.sh/v1", .env_var = "AI_GATEWAY_API_KEY", .default_model = "openai/gpt-5.5" },
@@ -1252,13 +1252,13 @@ pub fn envApiKey(environ: std.process.Environ, tag: Tag) ?[:0]const u8 {
     return switch (tag) {
         .anthropic => environ.getPosix("ANTHROPIC_API_KEY"),
         // OPENAI_BASE_URL gates OPENAI_API_KEY between `.openai` and
-        // `.generic_openai` so exactly one of them can ever detect it,
+        // `.openai_compatible` so exactly one of them can ever detect it,
         // mirroring the `.gemini`/`.vertex` split on GOOGLE_API_KEY.
         .openai => if (environ.getPosix("OPENAI_BASE_URL") == null)
             environ.getPosix("OPENAI_API_KEY")
         else
             null,
-        .generic_openai => if (environ.getPosix("OPENAI_BASE_URL") != null)
+        .openai_compatible => if (environ.getPosix("OPENAI_BASE_URL") != null)
             environ.getPosix("OPENAI_API_KEY")
         else
             null,
@@ -1291,7 +1291,7 @@ pub fn envVarName(tag: Tag) []const u8 {
         .openai => "OPENAI_API_KEY",
         .gemini => "GOOGLE_API_KEY/GEMINI_API_KEY",
         .vertex => "VERTEX_API_KEY/GOOGLE_API_KEY",
-        .generic_openai => "OPENAI_API_KEY",
+        .openai_compatible => "OPENAI_API_KEY",
         .codex => "a ChatGPT subscription (OAuth)",
         else => unreachable,
     };
@@ -1308,7 +1308,7 @@ pub fn defaultModel(tag: Tag) []const u8 {
         .anthropic => "claude-sonnet-5",
         .openai, .codex => "gpt-5.5",
         .gemini, .vertex => "gemini-3.6-flash",
-        .generic_openai => "",
+        .openai_compatible => "",
         else => unreachable,
     };
 }
@@ -1337,7 +1337,7 @@ pub const default_candidates: []const Tag = blk: {
     var arr: [all.len]Tag = undefined;
     var n: usize = 0;
     for (all) |t| {
-        // generic_openai is included; envApiKey gates it on OPENAI_BASE_URL.
+        // openai_compatible is included; envApiKey gates it on OPENAI_BASE_URL.
         if (openAiPreset(t)) |p| if (p.local) continue;
         arr[n] = t;
         n += 1;
@@ -1438,7 +1438,7 @@ pub fn listChatModelIds(
         const policy: retry.RetryPolicy = if (p.local and isLoopbackUrl(url)) .disabled else .{};
         try listOpenAICompatibleModelIds(io, allocator, arena, &ids, api_key, url, policy);
     } else switch (tag) {
-        .generic_openai => {
+        .openai_compatible => {
             const url = options.base_url orelse
                 options.environ.getPosix("OPENAI_BASE_URL") orelse return error.MissingBaseUrl;
             try listOpenAICompatibleModelIds(io, allocator, arena, &ids, api_key, url, .{});
@@ -1570,13 +1570,13 @@ test "vercel/mistral: real-key cloud presets, auto-detectable" {
     try std.testing.expect(saw_vercel and saw_mistral);
 }
 
-test "generic_openai: no static preset, env-gated key detection" {
-    try std.testing.expect(openAiPreset(.generic_openai) == null);
+test "openai_compatible: no static preset, env-gated key detection" {
+    try std.testing.expect(openAiPreset(.openai_compatible) == null);
     // Without OPENAI_BASE_URL the key must not be detected — that's `.openai`.
-    try std.testing.expect(envApiKey(.empty, .generic_openai) == null);
+    try std.testing.expect(envApiKey(.empty, .openai_compatible) == null);
 }
 
-test "openai/generic_openai: OPENAI_BASE_URL splits key detection" {
+test "openai/openai_compatible: OPENAI_BASE_URL splits key detection" {
     // Environ.PosixBlock is not the block representation on Windows.
     if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
     const with_url: std.process.Environ = .{ .block = .{ .slice = &[_:null]?[*:0]const u8{
@@ -1584,24 +1584,24 @@ test "openai/generic_openai: OPENAI_BASE_URL splits key detection" {
         "OPENAI_API_KEY=sk-test",
     } } };
     try std.testing.expect(envApiKey(with_url, .openai) == null);
-    try std.testing.expectEqualStrings("sk-test", envApiKey(with_url, .generic_openai).?);
+    try std.testing.expectEqualStrings("sk-test", envApiKey(with_url, .openai_compatible).?);
 
     const without_url: std.process.Environ = .{ .block = .{ .slice = &[_:null]?[*:0]const u8{
         "OPENAI_API_KEY=sk-test",
     } } };
     try std.testing.expectEqualStrings("sk-test", envApiKey(without_url, .openai).?);
-    try std.testing.expect(envApiKey(without_url, .generic_openai) == null);
+    try std.testing.expect(envApiKey(without_url, .openai_compatible) == null);
 }
 
-test "generic_openai: envVarName and defaultModel" {
-    try std.testing.expectEqualStrings("OPENAI_API_KEY", envVarName(.generic_openai));
-    try std.testing.expectEqualStrings("", defaultModel(.generic_openai));
+test "openai_compatible: envVarName and defaultModel" {
+    try std.testing.expectEqualStrings("OPENAI_API_KEY", envVarName(.openai_compatible));
+    try std.testing.expectEqualStrings("", defaultModel(.openai_compatible));
 }
 
-test "generic_openai: present in default_candidates (runtime-gated)" {
+test "openai_compatible: present in default_candidates (runtime-gated)" {
     var found = false;
     for (default_candidates) |t| {
-        if (t == .generic_openai) found = true;
+        if (t == .openai_compatible) found = true;
     }
     try std.testing.expect(found);
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -35,6 +35,11 @@ pub const huggingface = openai;
 /// with a different default base URL (`http://localhost:8080/v1`).
 pub const llama_cpp = openai;
 
+/// Generic OpenAI-compatible Chat Completions API. Auto-detected when
+/// `OPENAI_BASE_URL` is set — use it for any server that speaks the OpenAI
+/// chat completions wire format (vLLM, LiteLLM, Together, Groq, etc.).
+pub const generic_openai = openai;
+
 /// Vercel AI Gateway and Mistral both use the OpenAI-compatible Chat Completions
 /// API with their own default base URLs.
 pub const vercel = openai;

--- a/src/root.zig
+++ b/src/root.zig
@@ -44,7 +44,7 @@ pub const llama_cpp = openai;
 /// Generic OpenAI-compatible Chat Completions API. Auto-detected when
 /// `OPENAI_BASE_URL` is set — use it for any server that speaks the OpenAI
 /// chat completions wire format (vLLM, LiteLLM, Together, Groq, etc.).
-pub const generic_openai = openai;
+pub const openai_compatible = openai;
 
 /// Vercel AI Gateway and Mistral both use the OpenAI-compatible Chat Completions
 /// API with their own default base URLs.


### PR DESCRIPTION
I based some of this off how the llama.cpp and ollama custom providers are implemented on top of the OpenAI provider, but I am open to tweaking this. The predicate to using this generic OpenAI provider is just seeing if the OPENAI_BASE_URL env var is set. I am open to tweaking some of this.
Disclaimer: I did write this with the help of Deepseek V4 Flash.