### PR TITLE
feat(search): add Keenable search client

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const retry = @import("retry.zig");
 
 /// Error set returned by `fetchJsonWithRetry`. Each provider's `ApiError`
-/// is a superset (it adds `MissingApiKey`).
+/// is a superset, adding its own preflight errors (`MissingApiKey` for the
+/// keyed providers; keenable, which supports keyless calls, adds
+/// `MissingAppTitle` instead).
 pub const FetchError = error{
     ApiError,
     EmptyResponse,
@@ -259,8 +261,9 @@ fn fetchCapturingRetryAfter(
     return response.head.status;
 }
 
-/// Error set returned by `streamSse`. Each provider's `StreamError` is a
-/// superset (it adds `MissingApiKey`, which callers check before streaming).
+/// Error set returned by `streamSse`. Each streaming provider's
+/// `StreamError` is a superset (it adds `MissingApiKey`, which callers
+/// check before streaming).
 pub const SseError = error{
     ApiError,
     InvalidSseData,

--- a/src/root.zig
+++ b/src/root.zig
@@ -66,6 +66,10 @@ pub const search = struct {
         pub const Client = @import("search/exa/Client.zig");
         pub const types = @import("search/exa/types.zig");
     };
+    pub const keenable = struct {
+        pub const Client = @import("search/keenable/Client.zig");
+        pub const types = @import("search/keenable/types.zig");
+    };
 };
 
 pub const provider = @import("provider.zig");

--- a/src/search/keenable/Client.zig
+++ b/src/search/keenable/Client.zig
@@ -2,10 +2,10 @@
 //!
 //! Keenable is an AI-friendly search API: a query goes in, a clean JSON list
 //! of `{title, url, snippet}` results comes out. Unlike the other search
-//! providers here it also works without an API key: with an empty `api_key`
-//! the client calls the public endpoint (rate-limited per client IP), which
-//! requires an application title header for attribution. A key lifts the
-//! rate limits; it is not a prerequisite.
+//! providers here it also works without an API key: pass `null` as `api_key`
+//! and the client calls the public endpoint (rate-limited per client IP),
+//! which requires an application title header for attribution. A key lifts
+//! the rate limits; it is not a prerequisite.
 
 const std = @import("std");
 const types = @import("types.zig");
@@ -20,7 +20,11 @@ const SearchResponse = types.SearchResponse;
 const Client = @This();
 
 allocator: std.mem.Allocator,
-api_key: []const u8,
+/// `null` selects the keyless public endpoint. A non-null key — even an
+/// empty one, e.g. from a set-but-empty environment variable — selects the
+/// keyed endpoint, so a misconfigured key fails loudly instead of silently
+/// changing endpoint and rate-limit regime.
+api_key: ?[]const u8,
 base_url: []const u8,
 app_title: []const u8,
 http_client: std.http.Client,
@@ -31,11 +35,14 @@ pub const InitOptions = struct {
     base_url: []const u8 = "https://api.keenable.ai",
     /// Sent as `X-Keenable-Title`. Required by the keyless endpoint (it
     /// rejects requests without one); pure attribution on keyed calls.
-    app_title: []const u8 = "zenai",
+    /// Deliberately no default: only the embedding application knows its
+    /// own name, and a library default would self-attribute every embedder
+    /// that forgets to set it.
+    app_title: []const u8,
     retry_policy: RetryPolicy = .{},
 };
 
-pub fn init(io: std.Io, allocator: std.mem.Allocator, api_key: []const u8, options: InitOptions) Client {
+pub fn init(io: std.Io, allocator: std.mem.Allocator, api_key: ?[]const u8, options: InitOptions) Client {
     return .{
         .allocator = allocator,
         .api_key = api_key,
@@ -53,16 +60,17 @@ pub fn deinit(self: *Client) void {
 
 pub const Response = http.Response;
 
-/// No `MissingApiKey`: an empty key routes to the public endpoint instead.
-pub const ApiError = http.FetchError;
+/// No `MissingApiKey` — a `null` key is the supported keyless mode. What is
+/// required instead is the attribution title, checked before any request.
+pub const ApiError = error{MissingAppTitle} || http.FetchError;
 
 pub fn setErrorDetail(self: *Client, status_code: u10, body: []const u8) void {
     self.last_error.set(self.allocator, status_code, body);
 }
 
 /// `/v1/search` keyed, `/v1/search/public` keyless.
-fn searchPath(api_key: []const u8) []const u8 {
-    return if (api_key.len == 0) "/v1/search/public" else "/v1/search";
+fn searchPath(api_key: ?[]const u8) []const u8 {
+    return if (api_key == null) "/v1/search/public" else "/v1/search";
 }
 
 /// Run a search. Caller owns the returned `Response` and must call `deinit()`.
@@ -71,6 +79,8 @@ pub fn search(
     query: []const u8,
     options: SearchOptions,
 ) ApiError!Response(SearchResponse) {
+    if (self.app_title.len == 0) return error.MissingAppTitle;
+
     const url = try std.fmt.allocPrint(self.allocator, "{s}{s}", .{ self.base_url, searchPath(self.api_key) });
     defer self.allocator.free(url);
 
@@ -81,25 +91,30 @@ pub fn search(
     std.json.Stringify.value(request, .{ .emit_null_optional_fields = false }, &payload_buf.writer) catch
         return error.OutOfMemory;
 
-    var headers_buf: [2]std.http.Header = undefined;
-    var n: usize = 0;
-    headers_buf[n] = .{ .name = "X-Keenable-Title", .value = self.app_title };
-    n += 1;
-    if (self.api_key.len > 0) {
-        headers_buf[n] = .{ .name = "X-API-Key", .value = self.api_key };
-        n += 1;
-    }
+    const headers = [_]std.http.Header{
+        .{ .name = "X-Keenable-Title", .value = self.app_title },
+        .{ .name = "X-API-Key", .value = self.api_key orelse "" },
+    };
 
     return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, .{
         .location = .{ .url = url },
         .method = .POST,
         .payload = payload_buf.written(),
-        .extra_headers = headers_buf[0..n],
+        .extra_headers = headers[0..if (self.api_key == null) 1 else 2],
         .headers = .{ .content_type = .{ .override = "application/json" } },
     }, SearchResponse, self);
 }
 
-test "empty api key routes to the public endpoint" {
-    try std.testing.expectEqualStrings("/v1/search/public", searchPath(""));
+test "null api key routes to the public endpoint" {
+    try std.testing.expectEqualStrings("/v1/search/public", searchPath(null));
     try std.testing.expectEqualStrings("/v1/search", searchPath("sk-abc"));
+    // Set-but-empty is keyed on purpose: it fails loudly server-side rather
+    // than silently downgrading to the keyless rate-limit regime.
+    try std.testing.expectEqualStrings("/v1/search", searchPath(""));
+}
+
+test "search rejects an empty app title" {
+    var client = init(std.testing.io, std.testing.allocator, null, .{ .app_title = "" });
+    defer client.deinit();
+    try std.testing.expectError(error.MissingAppTitle, client.search("anything", .{}));
 }

--- a/src/search/keenable/Client.zig
+++ b/src/search/keenable/Client.zig
@@ -1,0 +1,105 @@
+//! Keenable Search API client. https://docs.keenable.ai/
+//!
+//! Keenable is an AI-friendly search API: a query goes in, a clean JSON list
+//! of `{title, url, snippet}` results comes out. Unlike the other search
+//! providers here it also works without an API key: with an empty `api_key`
+//! the client calls the public endpoint (rate-limited per client IP), which
+//! requires an application title header for attribution. A key lifts the
+//! rate limits; it is not a prerequisite.
+
+const std = @import("std");
+const types = @import("types.zig");
+const http = @import("../../http.zig");
+const retry = @import("../../retry.zig");
+
+pub const RetryPolicy = retry.RetryPolicy;
+
+const SearchOptions = types.SearchOptions;
+const SearchResponse = types.SearchResponse;
+
+const Client = @This();
+
+allocator: std.mem.Allocator,
+api_key: []const u8,
+base_url: []const u8,
+app_title: []const u8,
+http_client: std.http.Client,
+retry_policy: RetryPolicy,
+last_error: http.ErrorDetail = .{},
+
+pub const InitOptions = struct {
+    base_url: []const u8 = "https://api.keenable.ai",
+    /// Sent as `X-Keenable-Title`. Required by the keyless endpoint (it
+    /// rejects requests without one); pure attribution on keyed calls.
+    app_title: []const u8 = "zenai",
+    retry_policy: RetryPolicy = .{},
+};
+
+pub fn init(io: std.Io, allocator: std.mem.Allocator, api_key: []const u8, options: InitOptions) Client {
+    return .{
+        .allocator = allocator,
+        .api_key = api_key,
+        .base_url = options.base_url,
+        .app_title = options.app_title,
+        .http_client = .{ .allocator = allocator, .io = io },
+        .retry_policy = options.retry_policy,
+    };
+}
+
+pub fn deinit(self: *Client) void {
+    self.http_client.deinit();
+    self.last_error.deinit(self.allocator);
+}
+
+pub const Response = http.Response;
+
+/// No `MissingApiKey`: an empty key routes to the public endpoint instead.
+pub const ApiError = http.FetchError;
+
+pub fn setErrorDetail(self: *Client, status_code: u10, body: []const u8) void {
+    self.last_error.set(self.allocator, status_code, body);
+}
+
+/// `/v1/search` keyed, `/v1/search/public` keyless.
+fn searchPath(api_key: []const u8) []const u8 {
+    return if (api_key.len == 0) "/v1/search/public" else "/v1/search";
+}
+
+/// Run a search. Caller owns the returned `Response` and must call `deinit()`.
+pub fn search(
+    self: *Client,
+    query: []const u8,
+    options: SearchOptions,
+) ApiError!Response(SearchResponse) {
+    const url = try std.fmt.allocPrint(self.allocator, "{s}{s}", .{ self.base_url, searchPath(self.api_key) });
+    defer self.allocator.free(url);
+
+    var request = options;
+    request.query = query;
+    var payload_buf: std.Io.Writer.Allocating = .init(self.allocator);
+    defer payload_buf.deinit();
+    std.json.Stringify.value(request, .{ .emit_null_optional_fields = false }, &payload_buf.writer) catch
+        return error.OutOfMemory;
+
+    var headers_buf: [2]std.http.Header = undefined;
+    var n: usize = 0;
+    headers_buf[n] = .{ .name = "X-Keenable-Title", .value = self.app_title };
+    n += 1;
+    if (self.api_key.len > 0) {
+        headers_buf[n] = .{ .name = "X-API-Key", .value = self.api_key };
+        n += 1;
+    }
+
+    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, .{
+        .location = .{ .url = url },
+        .method = .POST,
+        .payload = payload_buf.written(),
+        .extra_headers = headers_buf[0..n],
+        .headers = .{ .content_type = .{ .override = "application/json" } },
+    }, SearchResponse, self);
+}
+
+test "empty api key routes to the public endpoint" {
+    try std.testing.expectEqualStrings("/v1/search/public", searchPath(""));
+    try std.testing.expectEqualStrings("/v1/search", searchPath("sk-abc"));
+}

--- a/src/search/keenable/types.zig
+++ b/src/search/keenable/types.zig
@@ -6,10 +6,11 @@ pub const Result = struct {
     title: []const u8 = "",
     url: []const u8 = "",
     /// The page-text excerpt — this is the field that carries the result's
-    /// text. `description` (the page's meta description) comes back empty on
-    /// essentially every result; read `snippet`.
+    /// text. The wire format also has `description` (the page's meta
+    /// description), which comes back empty on essentially every result; it
+    /// is deliberately not mapped, so nothing can bind to it by mistake —
+    /// parsing ignores unknown fields.
     snippet: []const u8 = "",
-    description: []const u8 = "",
     published_at: ?[]const u8 = null,
     acquired_at: ?[]const u8 = null,
 };
@@ -37,7 +38,9 @@ pub const SearchOptions = struct {
 };
 
 test "SearchResponse parses Keenable fixture" {
-    // Real response shape: `description` present but empty, text in `snippet`.
+    // Real response shape: `description` present but empty, text in
+    // `snippet`. The fixture keeps `description` to prove the unmapped
+    // field is ignored, not tripped over.
     const fixture =
         \\{
         \\  "query": "zig systems programming language",
@@ -54,7 +57,6 @@ test "SearchResponse parses Keenable fixture" {
     try std.testing.expectEqual(@as(usize, 2), parsed.value.results.len);
     try std.testing.expectEqualStrings("Zig (programming language)", parsed.value.results[0].title);
     try std.testing.expectEqualStrings("Zig is a system programming language.", parsed.value.results[0].snippet);
-    try std.testing.expectEqualStrings("", parsed.value.results[0].description);
 }
 
 test "SearchOptions stringifies with no null fields" {

--- a/src/search/keenable/types.zig
+++ b/src/search/keenable/types.zig
@@ -1,0 +1,71 @@
+//! Keenable Search API request/response shapes. https://docs.keenable.ai/
+
+const std = @import("std");
+
+pub const Result = struct {
+    title: []const u8 = "",
+    url: []const u8 = "",
+    /// The page-text excerpt — this is the field that carries the result's
+    /// text. `description` (the page's meta description) comes back empty on
+    /// essentially every result; read `snippet`.
+    snippet: []const u8 = "",
+    description: []const u8 = "",
+    published_at: ?[]const u8 = null,
+    acquired_at: ?[]const u8 = null,
+};
+
+pub const SearchResponse = struct {
+    query: []const u8 = "",
+    mode: ?[]const u8 = null,
+    results: []const Result = &.{},
+};
+
+/// Doubles as the request body: `Client.search` fills in `query`.
+pub const SearchOptions = struct {
+    query: []const u8 = "",
+    /// 1–50 (provider default 10).
+    max_results: ?u8 = null,
+    /// Excerpt budget per result, in characters. The API treats it as a
+    /// hint and may round up to a word boundary — enforce locally when the
+    /// budget is a hard cap.
+    snippet_max_length: ?u16 = null,
+    /// Restrict results to one site, e.g. "ziglang.org".
+    site: ?[]const u8 = null,
+    /// ISO dates (YYYY-MM-DD).
+    published_after: ?[]const u8 = null,
+    published_before: ?[]const u8 = null,
+};
+
+test "SearchResponse parses Keenable fixture" {
+    // Real response shape: `description` present but empty, text in `snippet`.
+    const fixture =
+        \\{
+        \\  "query": "zig systems programming language",
+        \\  "mode": "pro",
+        \\  "results": [
+        \\    {"title": "Zig (programming language)", "url": "https://en.wikipedia.org/wiki/Zig_(programming_language)", "description": "", "snippet": "Zig is a system programming language.", "published_at": "2026-08-15T09:22:57Z", "acquired_at": "2026-08-21T05:39:17Z"},
+        \\    {"title": "Zig guide", "url": "https://example.org/zig", "description": "", "snippet": "Compile-time execution."}
+        \\  ]
+        \\}
+    ;
+    const parsed = try std.json.parseFromSlice(SearchResponse, std.testing.allocator, fixture, .{ .ignore_unknown_fields = true });
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("zig systems programming language", parsed.value.query);
+    try std.testing.expectEqual(@as(usize, 2), parsed.value.results.len);
+    try std.testing.expectEqualStrings("Zig (programming language)", parsed.value.results[0].title);
+    try std.testing.expectEqualStrings("Zig is a system programming language.", parsed.value.results[0].snippet);
+    try std.testing.expectEqualStrings("", parsed.value.results[0].description);
+}
+
+test "SearchOptions stringifies with no null fields" {
+    var buf: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer buf.deinit();
+    try std.json.Stringify.value(SearchOptions{
+        .query = "zig",
+        .max_results = 10,
+        .snippet_max_length = 500,
+    }, .{ .emit_null_optional_fields = false }, &buf.writer);
+    try std.testing.expectEqualStrings(
+        \\{"query":"zig","max_results":10,"snippet_max_length":500}
+    , buf.written());
+}


### PR DESCRIPTION
Adds a Keenable Search API client next to tavily/brave/exa (POST JSON, mirrors the tavily client's plumbing).

One deliberate difference: it also works with no API key — an empty `api_key` routes to the public endpoint (`/v1/search/public`, rate-limited per client IP), which requires the `X-Keenable-Title` attribution header (`InitOptions.app_title`). A key lifts the rate limits via `/v1/search` + `X-API-Key`. `ApiError` therefore drops `MissingApiKey`: keyless is a supported mode, not an error.

The fixture test pins the real response shape: the result text lives in `snippet`; `description` (meta description) is present but empty on essentially every result.

`zig build test`: 105/105 pass. `zig fmt --check src/` clean (Zig 0.16.0).

Companion PR wiring it into the browser's `search` tool follows in lightpanda-io/browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)