### PR TITLE
feat(http): bound requests with a watchdog timeout

### DIFF
--- a/src/anthropic/Client.zig
+++ b/src/anthropic/Client.zig
@@ -22,6 +22,10 @@ api_version: []const u8,
 http_client: std.http.Client,
 /// Retry policy applied to every non-streaming request.
 retry_policy: RetryPolicy,
+/// Per-attempt wall-clock bound on non-streaming requests, from an
+/// established connection to the end of the body (connect excluded);
+/// exceeding it fails with `error.Timeout`. `null` waits indefinitely.
+request_timeout_ms: ?u32,
 /// Human-readable message from the most recent API error, owned by the client
 /// and freed on the next failure or `deinit`. Set on `error.ApiError`.
 last_error_message: ?[]u8 = null,
@@ -39,6 +43,10 @@ pub const InitOptions = struct {
     /// `overloaded_error`, 429, and known flaky network errors). Pass
     /// `RetryPolicy.disabled` to opt out.
     retry_policy: RetryPolicy = .{},
+    /// Per-attempt wall-clock bound on non-streaming requests, from an
+    /// established connection to the end of the body (connect excluded);
+    /// exceeding it fails with `error.Timeout`. `null` waits indefinitely.
+    request_timeout_ms: ?u32 = null,
 };
 
 /// Create a new Anthropic API client.
@@ -50,6 +58,7 @@ pub fn init(io: std.Io, allocator: std.mem.Allocator, api_key: []const u8, optio
         .api_version = options.api_version,
         .http_client = .{ .allocator = allocator, .io = io },
         .retry_policy = options.retry_policy,
+        .request_timeout_ms = options.request_timeout_ms,
         .last_error_message = null,
         .last_error_status = null,
     };
@@ -92,7 +101,7 @@ pub fn setErrorDetail(self: *Client, status_code: u10, body: []const u8) void {
 
 fn fetchGet(self: *Client, url: []const u8, comptime T: type) ApiError!Response(T) {
     const auth = self.authHeaders();
-    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, .{
+    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, self.request_timeout_ms, .{
         .location = .{ .url = url },
         .method = .GET,
         .extra_headers = &auth,
@@ -106,7 +115,7 @@ fn fetchPost(self: *Client, url: []const u8, body: anytype, comptime T: type) Ap
         return error.OutOfMemory;
 
     const auth = self.authHeaders();
-    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, .{
+    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, self.request_timeout_ms, .{
         .location = .{ .url = url },
         .method = .POST,
         .payload = payload_buf.written(),

--- a/src/codex/Client.zig
+++ b/src/codex/Client.zig
@@ -40,8 +40,10 @@ pub const InitOptions = struct {
     session_id: ?[]const u8 = null,
     originator: []const u8 = "lightpanda",
     user_agent: []const u8 = "lightpanda",
-    /// Accepted for uniform provider init; the streaming-only path never retries.
+    /// Accepted for uniform provider init; the streaming-only path never
+    /// retries and is not bounded by `request_timeout_ms`.
     retry_policy: RetryPolicy = .{},
+    request_timeout_ms: ?u32 = null,
 };
 
 pub fn init(io: std.Io, allocator: std.mem.Allocator, access_token: []const u8, options: InitOptions) !Client {

--- a/src/gemini/Client.zig
+++ b/src/gemini/Client.zig
@@ -29,6 +29,10 @@ vertex: ?VertexConfig,
 http_client: std.http.Client,
 /// Retry policy applied to every non-streaming request.
 retry_policy: RetryPolicy,
+/// Per-attempt wall-clock bound on non-streaming requests, from an
+/// established connection to the end of the body (connect excluded);
+/// exceeding it fails with `error.Timeout`. `null` waits indefinitely.
+request_timeout_ms: ?u32,
 /// Cached "Bearer {token}" header value for Vertex project/location mode.
 /// Built on first request; owned, freed in `deinit`.
 bearer_value: ?[]u8 = null,
@@ -66,6 +70,10 @@ pub const InitOptions = struct {
     /// Retry policy for transient HTTP failures (5xx, 429, and known
     /// flaky network errors). Pass `RetryPolicy.disabled` to opt out.
     retry_policy: RetryPolicy = .{},
+    /// Per-attempt wall-clock bound on non-streaming requests, from an
+    /// established connection to the end of the body (connect excluded);
+    /// exceeding it fails with `error.Timeout`. `null` waits indefinitely.
+    request_timeout_ms: ?u32 = null,
     /// Target Vertex AI instead of the Gemini Developer API.
     vertex: ?VertexConfig = null,
 };
@@ -84,6 +92,7 @@ pub fn init(io: std.Io, allocator: std.mem.Allocator, api_key: []const u8, optio
         .vertex = options.vertex,
         .http_client = .{ .allocator = allocator, .io = io },
         .retry_policy = options.retry_policy,
+        .request_timeout_ms = options.request_timeout_ms,
         .last_error_message = null,
         .last_error_status = null,
     };
@@ -226,7 +235,7 @@ fn writeModelUrl(self: *const Client, w: *std.Io.Writer, model: []const u8, opts
 
 fn fetchGet(self: *Client, url: []const u8, comptime T: type) ApiError!Response(T) {
     const auth = [1]std.http.Header{try self.authHeader()};
-    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, .{
+    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, self.request_timeout_ms, .{
         .location = .{ .url = url },
         .extra_headers = &auth,
     }, T, self);
@@ -239,7 +248,7 @@ fn fetchPost(self: *Client, url: []const u8, body: anytype, comptime T: type) Ap
         return error.OutOfMemory;
 
     const auth = [1]std.http.Header{try self.authHeader()};
-    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, .{
+    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, self.request_timeout_ms, .{
         .location = .{ .url = url },
         .method = .POST,
         .payload = payload_buf.written(),

--- a/src/http.zig
+++ b/src/http.zig
@@ -104,43 +104,39 @@ pub fn armInterrupt(interrupt: ?*Interrupt, req: *std.http.Client.Request) Inter
 /// down at the deadline, exactly as a Ctrl-C would, so the blocking read
 /// fails instead of waiting on the server. The connect phase is out of
 /// reach: std's `ConnectTcpOptions.timeout` is declared but unimplemented.
+///
+/// A raw `std.Thread` rather than `io.concurrent`: consumers run a
+/// single-threaded `Io.Threaded`, where `concurrent` is unavailable and
+/// cancellation is a no-op. One fixed deadline for the whole exchange, so
+/// not suitable for long-lived streams without a resettable deadline.
 const Watchdog = struct {
     interrupt: Interrupt = .{},
     done: std.Io.Event = .unset,
-    io: std.Io = undefined,
     thread: ?std.Thread = null,
 
-    fn start(self: *Watchdog, io: std.Io, req: *const std.http.Client.Request, timeout_ms: u32) error{SystemResources}!void {
-        const conn = req.connection orelse return;
-        self.io = io;
-        self.interrupt.arm(&conn.stream_reader);
+    fn start(self: *Watchdog, io: std.Io, req: *std.http.Client.Request, timeout_ms: u32) error{SystemResources}!void {
+        _ = armInterrupt(&self.interrupt, req);
         const deadline: std.Io.Clock.Timestamp = .fromNow(io, .{ .raw = .fromMilliseconds(timeout_ms), .clock = .awake });
-        self.thread = std.Thread.spawn(.{ .stack_size = 256 * 1024 }, run, .{ self, deadline }) catch return error.SystemResources;
+        self.thread = std.Thread.spawn(.{ .stack_size = 256 * 1024 }, run, .{ self, io, deadline }) catch return error.SystemResources;
     }
 
-    fn run(self: *Watchdog, deadline: std.Io.Clock.Timestamp) void {
-        while (!self.done.isSet()) {
-            self.done.waitTimeout(self.io, .{ .deadline = deadline }) catch |err| switch (err) {
-                error.Canceled => return,
-                // Spurious wakeups also report Timeout; only the deadline counts.
-                error.Timeout => if (deadline.durationFromNow(self.io).raw.nanoseconds <= 0) {
-                    self.interrupt.fire();
-                    return;
-                },
-            };
+    fn run(self: *Watchdog, io: std.Io, deadline: std.Io.Clock.Timestamp) void {
+        // Spurious wakeups (e.g. EINTR) also report Timeout; only the deadline counts.
+        while (true) {
+            if (self.done.waitTimeout(io, .{ .deadline = deadline })) |_| return else |_| {}
+            if (deadline.compare(.lte, .now(io, .awake))) break;
         }
+        self.interrupt.fire();
     }
 
     /// Must run before `req.deinit`: joins the thread so a late `fire` can't
-    /// hit a recycled socket, and drops a connection the deadline shut down
+    /// hit a recycled socket, and poisons a connection the deadline shut down
     /// just after the body had already completed.
-    fn stop(self: *Watchdog, req: *std.http.Client.Request) void {
+    fn stop(self: *Watchdog, io: std.Io, guard: InterruptGuard) void {
         const thread = self.thread orelse return;
-        self.done.set(self.io);
+        self.done.set(io);
         thread.join();
-        if (self.interrupt.isFired()) {
-            if (req.connection) |conn| conn.closing = true;
-        }
+        if (self.interrupt.isFired()) guard.poison();
     }
 };
 
@@ -148,11 +144,14 @@ const Watchdog = struct {
 /// clients. On a non-retryable HTTP error response, calls
 /// `error_handler.setErrorDetail(status, body)` so the caller can record
 /// provider-specific error detail before this function returns
-/// `error.ApiError`.
+/// `error.ApiError`. `timeout_ms` bounds each attempt from an established
+/// connection to the end of the body (see `Watchdog`); null waits
+/// indefinitely.
 pub fn fetchJsonWithRetry(
     allocator: std.mem.Allocator,
     http_client: *std.http.Client,
     policy: retry.RetryPolicy,
+    timeout_ms: ?u32,
     options: std.http.Client.FetchOptions,
     comptime T: type,
     error_handler: anytype,
@@ -161,10 +160,6 @@ pub fn fetchJsonWithRetry(
     // in-flight read; clients without the field (e.g. tavily) opt out at comptime.
     const interrupt: ?*Interrupt = if (@hasField(@TypeOf(error_handler.*), "interrupt"))
         error_handler.interrupt
-    else
-        null;
-    const timeout_ms: ?u32 = if (@hasField(@TypeOf(error_handler.*), "request_timeout_ms"))
-        error_handler.request_timeout_ms
     else
         null;
     var attempt: u8 = 0;
@@ -278,7 +273,7 @@ fn fetchCapturingRetryAfter(
 
     var watchdog: Watchdog = .{};
     if (timeout_ms) |ms| try watchdog.start(client.io, &req, ms);
-    defer watchdog.stop(&req);
+    defer watchdog.stop(client.io, guard);
 
     return exchange(allocator, &req, redirect_behavior, options, response_writer, retry_after_ms) catch |err| {
         if (watchdog.interrupt.isFired()) return error.Timeout;
@@ -286,6 +281,9 @@ fn fetchCapturingRetryAfter(
     };
 }
 
+/// The send/receive half of `fetchCapturingRetryAfter`, split out so its
+/// caller can map any failure that lands while the watchdog has fired to
+/// `error.Timeout`.
 fn exchange(
     allocator: std.mem.Allocator,
     req: *std.http.Client.Request,
@@ -550,19 +548,9 @@ test "watchdog turns a stalled response into error.Timeout" {
     var server = try loopback.listen(io, .{});
     defer server.deinit(io);
 
-    // Accept the request and hold the connection open without answering
-    // until the client side has given up.
-    var release: std.Io.Event = .unset;
-    const Stall = struct {
-        fn run(srv: *std.Io.net.Server, ev: *std.Io.Event, ioo: std.Io) void {
-            const stream = srv.accept(ioo) catch return;
-            defer stream.close(ioo);
-            ev.waitUncancelable(ioo);
-        }
-    };
-    const staller = try std.Thread.spawn(.{}, Stall.run, .{ &server, &release, io });
-    defer staller.join();
-    defer release.set(io);
+    // Never accept: the kernel completes the handshake into the backlog and
+    // buffers the request, so the client blocks in receiveHead until the
+    // watchdog shuts the socket down.
 
     const url = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}/", .{server.socket.address.getPort()});
     defer allocator.free(url);
@@ -574,6 +562,6 @@ test "watchdog turns a stalled response into error.Timeout" {
     var retry_after_ms: ?u32 = null;
     try std.testing.expectError(
         error.Timeout,
-        fetchCapturingRetryAfter(allocator, &client, .{ .location = .{ .url = url } }, &out.writer, null, 200, &retry_after_ms),
+        fetchCapturingRetryAfter(allocator, &client, .{ .location = .{ .url = url } }, &out.writer, null, 50, &retry_after_ms),
     );
 }

--- a/src/http.zig
+++ b/src/http.zig
@@ -99,6 +99,51 @@ pub fn armInterrupt(interrupt: ?*Interrupt, req: *std.http.Client.Request) Inter
     return .{ .interrupt = interrupt, .req = req };
 }
 
+/// Bounds one request's wall-clock time from an established connection to
+/// the end of the response body. A private `Interrupt` shuts the socket
+/// down at the deadline, exactly as a Ctrl-C would, so the blocking read
+/// fails instead of waiting on the server. The connect phase is out of
+/// reach: std's `ConnectTcpOptions.timeout` is declared but unimplemented.
+const Watchdog = struct {
+    interrupt: Interrupt = .{},
+    done: std.Io.Event = .unset,
+    io: std.Io = undefined,
+    thread: ?std.Thread = null,
+
+    fn start(self: *Watchdog, io: std.Io, req: *const std.http.Client.Request, timeout_ms: u32) error{SystemResources}!void {
+        const conn = req.connection orelse return;
+        self.io = io;
+        self.interrupt.arm(&conn.stream_reader);
+        const deadline: std.Io.Clock.Timestamp = .fromNow(io, .{ .raw = .fromMilliseconds(timeout_ms), .clock = .awake });
+        self.thread = std.Thread.spawn(.{ .stack_size = 256 * 1024 }, run, .{ self, deadline }) catch return error.SystemResources;
+    }
+
+    fn run(self: *Watchdog, deadline: std.Io.Clock.Timestamp) void {
+        while (!self.done.isSet()) {
+            self.done.waitTimeout(self.io, .{ .deadline = deadline }) catch |err| switch (err) {
+                error.Canceled => return,
+                // Spurious wakeups also report Timeout; only the deadline counts.
+                error.Timeout => if (deadline.durationFromNow(self.io).raw.nanoseconds <= 0) {
+                    self.interrupt.fire();
+                    return;
+                },
+            };
+        }
+    }
+
+    /// Must run before `req.deinit`: joins the thread so a late `fire` can't
+    /// hit a recycled socket, and drops a connection the deadline shut down
+    /// just after the body had already completed.
+    fn stop(self: *Watchdog, req: *std.http.Client.Request) void {
+        const thread = self.thread orelse return;
+        self.done.set(self.io);
+        thread.join();
+        if (self.interrupt.isFired()) {
+            if (req.connection) |conn| conn.closing = true;
+        }
+    }
+};
+
 /// Common HTTP fetch + retry + JSON parse pipeline shared by all provider
 /// clients. On a non-retryable HTTP error response, calls
 /// `error_handler.setErrorDetail(status, body)` so the caller can record
@@ -118,6 +163,10 @@ pub fn fetchJsonWithRetry(
         error_handler.interrupt
     else
         null;
+    const timeout_ms: ?u32 = if (@hasField(@TypeOf(error_handler.*), "request_timeout_ms"))
+        error_handler.request_timeout_ms
+    else
+        null;
     var attempt: u8 = 0;
     while (true) : (attempt += 1) {
         var response_buf: std.Io.Writer.Allocating = .init(allocator);
@@ -125,7 +174,7 @@ pub fn fetchJsonWithRetry(
         defer if (!keep_buf) response_buf.deinit();
 
         var retry_after_ms: ?u32 = null;
-        const status = fetchCapturingRetryAfter(allocator, http_client, options, &response_buf.writer, interrupt, &retry_after_ms) catch |err| {
+        const status = fetchCapturingRetryAfter(allocator, http_client, options, &response_buf.writer, interrupt, timeout_ms, &retry_after_ms) catch |err| {
             // Don't retry a request the user cancelled.
             if (interrupt) |it| if (it.isFired()) return err;
             if (retry.isRetryableFetchError(err) and attempt + 1 < policy.max_attempts) {
@@ -165,7 +214,7 @@ pub fn fetchInterruptible(
     interrupt: ?*Interrupt,
 ) std.http.Client.FetchError!std.http.Status {
     var retry_after_ms: ?u32 = null;
-    return fetchCapturingRetryAfter(allocator, client, options, response_writer, interrupt, &retry_after_ms);
+    return fetchCapturingRetryAfter(allocator, client, options, response_writer, interrupt, null, &retry_after_ms);
 }
 
 /// Server-provided retry hint from a response head: `Retry-After-Ms`
@@ -187,13 +236,16 @@ fn retryAfterFromHead(head: std.http.Client.Response.Head) ?u32 {
 
 /// `fetchInterruptible` plus capture of the response's Retry-After hint into
 /// `retry_after_ms` (read from the head before the body is streamed, while
-/// the header bytes are still valid) so `fetchJsonWithRetry` can honor it.
+/// the header bytes are still valid) so `fetchJsonWithRetry` can honor it,
+/// and an optional `timeout_ms` after which the exchange fails with
+/// `error.Timeout` (see `Watchdog`).
 fn fetchCapturingRetryAfter(
     allocator: std.mem.Allocator,
     client: *std.http.Client,
     options: std.http.Client.FetchOptions,
     response_writer: *std.Io.Writer,
     interrupt: ?*Interrupt,
+    timeout_ms: ?u32,
     retry_after_ms: *?u32,
 ) std.http.Client.FetchError!std.http.Status {
     const uri = switch (options.location) {
@@ -224,6 +276,24 @@ fn fetchCapturingRetryAfter(
     defer guard.deinit();
     errdefer guard.poison();
 
+    var watchdog: Watchdog = .{};
+    if (timeout_ms) |ms| try watchdog.start(client.io, &req, ms);
+    defer watchdog.stop(&req);
+
+    return exchange(allocator, &req, redirect_behavior, options, response_writer, retry_after_ms) catch |err| {
+        if (watchdog.interrupt.isFired()) return error.Timeout;
+        return err;
+    };
+}
+
+fn exchange(
+    allocator: std.mem.Allocator,
+    req: *std.http.Client.Request,
+    redirect_behavior: std.http.Client.Request.RedirectBehavior,
+    options: std.http.Client.FetchOptions,
+    response_writer: *std.Io.Writer,
+    retry_after_ms: *?u32,
+) std.http.Client.FetchError!std.http.Status {
     if (options.payload) |payload| {
         req.transfer_encoding = .{ .content_length = payload.len };
         var body = try req.sendBodyUnflushed(&.{});
@@ -470,4 +540,40 @@ pub fn appendListParams(allocator: std.mem.Allocator, base_url: []const u8, opti
         return std.fmt.allocPrint(allocator, "{s}?pageSize={d}", .{ base_url, ps });
     }
     return std.fmt.allocPrint(allocator, "{s}?pageToken={s}", .{ base_url, options.pageToken.? });
+}
+
+test "watchdog turns a stalled response into error.Timeout" {
+    const io = std.testing.io;
+    const allocator = std.testing.allocator;
+
+    const loopback: std.Io.net.IpAddress = try .parse("127.0.0.1", 0);
+    var server = try loopback.listen(io, .{});
+    defer server.deinit(io);
+
+    // Accept the request and hold the connection open without answering
+    // until the client side has given up.
+    var release: std.Io.Event = .unset;
+    const Stall = struct {
+        fn run(srv: *std.Io.net.Server, ev: *std.Io.Event, ioo: std.Io) void {
+            const stream = srv.accept(ioo) catch return;
+            defer stream.close(ioo);
+            ev.waitUncancelable(ioo);
+        }
+    };
+    const staller = try std.Thread.spawn(.{}, Stall.run, .{ &server, &release, io });
+    defer staller.join();
+    defer release.set(io);
+
+    const url = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}/", .{server.socket.address.getPort()});
+    defer allocator.free(url);
+
+    var client: std.http.Client = .{ .allocator = allocator, .io = io };
+    defer client.deinit();
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    defer out.deinit();
+    var retry_after_ms: ?u32 = null;
+    try std.testing.expectError(
+        error.Timeout,
+        fetchCapturingRetryAfter(allocator, &client, .{ .location = .{ .url = url } }, &out.writer, null, 200, &retry_after_ms),
+    );
 }

--- a/src/openai/Client.zig
+++ b/src/openai/Client.zig
@@ -27,6 +27,10 @@ bill_to: ?[]const u8,
 http_client: std.http.Client,
 /// Retry policy applied to every non-streaming request.
 retry_policy: RetryPolicy,
+/// Per-attempt wall-clock bound on non-streaming requests, from an
+/// established connection to the end of the body (connect excluded);
+/// exceeding it fails with `error.Timeout`. `null` waits indefinitely.
+request_timeout_ms: ?u32,
 /// Human-readable message from the most recent API error, owned by the client
 /// and freed on the next failure or `deinit`. Set on `error.ApiError`.
 last_error_message: ?[]u8 = null,
@@ -53,6 +57,10 @@ pub const InitOptions = struct {
     /// Retry policy for transient HTTP failures (5xx, 429, and known
     /// flaky network errors). Pass `RetryPolicy.disabled` to opt out.
     retry_policy: RetryPolicy = .{},
+    /// Per-attempt wall-clock bound on non-streaming requests, from an
+    /// established connection to the end of the body (connect excluded);
+    /// exceeding it fails with `error.Timeout`. `null` waits indefinitely.
+    request_timeout_ms: ?u32 = null,
 };
 
 /// Create a new OpenAI API client.
@@ -66,6 +74,7 @@ pub fn init(io: std.Io, allocator: std.mem.Allocator, api_key: []const u8, optio
         .bill_to = options.bill_to,
         .http_client = .{ .allocator = allocator, .io = io },
         .retry_policy = options.retry_policy,
+        .request_timeout_ms = options.request_timeout_ms,
         .last_error_message = null,
         .last_error_status = null,
     };
@@ -119,7 +128,7 @@ pub fn setErrorDetail(self: *Client, status_code: u10, body: []const u8) void {
 fn fetchGet(self: *Client, url: []const u8, comptime T: type) ApiError!Response(T) {
     var hdr_buf: [4]std.http.Header = undefined;
     const auth = try self.authHeaders(&hdr_buf);
-    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, .{
+    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, self.request_timeout_ms, .{
         .location = .{ .url = url },
         .extra_headers = auth,
     }, T, self);
@@ -133,7 +142,7 @@ fn fetchPost(self: *Client, url: []const u8, body: anytype, comptime T: type) Ap
 
     var hdr_buf: [4]std.http.Header = undefined;
     const auth = try self.authHeaders(&hdr_buf);
-    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, .{
+    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, self.request_timeout_ms, .{
         .location = .{ .url = url },
         .method = .POST,
         .payload = payload_buf.written(),

--- a/src/openai/ollama.zig
+++ b/src/openai/ollama.zig
@@ -125,7 +125,7 @@ fn fetchModelContextLength(client: *Client, model: []const u8) !?i32 {
         return error.OutOfMemory;
 
     const auth = [_]std.http.Header{.{ .name = "Authorization", .value = client.api_key }};
-    var response = try http.fetchJsonWithRetry(client.allocator, &client.http_client, client.retry_policy, .{
+    var response = try http.fetchJsonWithRetry(client.allocator, &client.http_client, client.retry_policy, client.request_timeout_ms, .{
         .location = .{ .url = url },
         .method = .POST,
         .payload = payload_buf.written(),
@@ -229,7 +229,7 @@ pub fn chat(
 
     // Local Ollama ignores auth; harmless, and supports an authenticating proxy.
     const auth = [_]std.http.Header{.{ .name = "Authorization", .value = client.api_key }};
-    return http.fetchJsonWithRetry(client.allocator, &client.http_client, client.retry_policy, .{
+    return http.fetchJsonWithRetry(client.allocator, &client.http_client, client.retry_policy, client.request_timeout_ms, .{
         .location = .{ .url = url },
         .method = .POST,
         .payload = payload_buf.written(),

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -452,6 +452,10 @@ pub const Client = union(enum) {
         /// `ollama_default_base_url` when null; the others use their own.
         base_url: ?[:0]const u8 = null,
         retry_policy: retry.RetryPolicy = .{},
+        /// Per-attempt wall-clock bound on non-streaming requests, from an
+        /// established connection to the end of the body (connect excluded);
+        /// exceeding it fails with `error.Timeout`. `null` waits indefinitely.
+        request_timeout_ms: ?u32 = null,
         /// Hugging Face org to bill via `X-HF-Bill-To`. Only applied to the
         /// OpenAI-compatible clients; ignored by gemini/anthropic.
         bill_to: ?[]const u8 = null,
@@ -489,7 +493,7 @@ pub const Client = union(enum) {
                     .openai_compatible => options.environ.getPosix("OPENAI_BASE_URL") orelse return error.MissingBaseUrl,
                     else => if (openAiPreset(tag)) |p| p.base_url else null,
                 };
-                var impl_opts: Impl.InitOptions = .{ .retry_policy = options.retry_policy };
+                var impl_opts: Impl.InitOptions = .{ .retry_policy = options.retry_policy, .request_timeout_ms = options.request_timeout_ms };
                 if (base_url) |u| impl_opts.base_url = u;
                 if (@hasField(Impl.InitOptions, "bill_to")) impl_opts.bill_to = options.bill_to;
                 if (@hasField(Impl.InitOptions, "account_id")) impl_opts.account_id = options.account_id;

--- a/src/search/brave/Client.zig
+++ b/src/search/brave/Client.zig
@@ -23,11 +23,16 @@ api_key: []const u8,
 base_url: []const u8,
 http_client: std.http.Client,
 retry_policy: RetryPolicy,
+request_timeout_ms: ?u32,
 last_error: http.ErrorDetail = .{},
 
 pub const InitOptions = struct {
     base_url: []const u8 = "https://api.search.brave.com",
     retry_policy: RetryPolicy = .{},
+    /// Per-attempt bound from an established connection to the end of the
+    /// response body, failing with `error.Timeout`; the connect phase is
+    /// not covered. `null` waits indefinitely.
+    request_timeout_ms: ?u32 = null,
 };
 
 pub fn init(io: std.Io, allocator: std.mem.Allocator, api_key: []const u8, options: InitOptions) Client {
@@ -37,6 +42,7 @@ pub fn init(io: std.Io, allocator: std.mem.Allocator, api_key: []const u8, optio
         .base_url = options.base_url,
         .http_client = .{ .allocator = allocator, .io = io },
         .retry_policy = options.retry_policy,
+        .request_timeout_ms = options.request_timeout_ms,
     };
 }
 

--- a/src/search/brave/Client.zig
+++ b/src/search/brave/Client.zig
@@ -29,9 +29,9 @@ last_error: http.ErrorDetail = .{},
 pub const InitOptions = struct {
     base_url: []const u8 = "https://api.search.brave.com",
     retry_policy: RetryPolicy = .{},
-    /// Per-attempt bound from an established connection to the end of the
-    /// response body, failing with `error.Timeout`; the connect phase is
-    /// not covered. `null` waits indefinitely.
+    /// Per-attempt wall-clock bound on non-streaming requests, from an
+    /// established connection to the end of the body (connect excluded);
+    /// exceeding it fails with `error.Timeout`. `null` waits indefinitely.
     request_timeout_ms: ?u32 = null,
 };
 
@@ -75,7 +75,7 @@ pub fn search(
         .{ .name = "Accept", .value = "application/json" },
     };
 
-    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, .{
+    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, self.request_timeout_ms, .{
         .location = .{ .url = url },
         .method = .GET,
         .extra_headers = &extra_headers,

--- a/src/search/exa/Client.zig
+++ b/src/search/exa/Client.zig
@@ -27,9 +27,9 @@ last_error: http.ErrorDetail = .{},
 pub const InitOptions = struct {
     base_url: []const u8 = "https://api.exa.ai",
     retry_policy: RetryPolicy = .{},
-    /// Per-attempt bound from an established connection to the end of the
-    /// response body, failing with `error.Timeout`; the connect phase is
-    /// not covered. `null` waits indefinitely.
+    /// Per-attempt wall-clock bound on non-streaming requests, from an
+    /// established connection to the end of the body (connect excluded);
+    /// exceeding it fails with `error.Timeout`. `null` waits indefinitely.
     request_timeout_ms: ?u32 = null,
 };
 
@@ -79,7 +79,7 @@ pub fn search(
         .{ .name = "x-api-key", .value = self.api_key },
     };
 
-    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, .{
+    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, self.request_timeout_ms, .{
         .location = .{ .url = url },
         .method = .POST,
         .payload = payload_buf.written(),

--- a/src/search/exa/Client.zig
+++ b/src/search/exa/Client.zig
@@ -21,11 +21,16 @@ api_key: []const u8,
 base_url: []const u8,
 http_client: std.http.Client,
 retry_policy: RetryPolicy,
+request_timeout_ms: ?u32,
 last_error: http.ErrorDetail = .{},
 
 pub const InitOptions = struct {
     base_url: []const u8 = "https://api.exa.ai",
     retry_policy: RetryPolicy = .{},
+    /// Per-attempt bound from an established connection to the end of the
+    /// response body, failing with `error.Timeout`; the connect phase is
+    /// not covered. `null` waits indefinitely.
+    request_timeout_ms: ?u32 = null,
 };
 
 pub fn init(io: std.Io, allocator: std.mem.Allocator, api_key: []const u8, options: InitOptions) Client {
@@ -35,6 +40,7 @@ pub fn init(io: std.Io, allocator: std.mem.Allocator, api_key: []const u8, optio
         .base_url = options.base_url,
         .http_client = .{ .allocator = allocator, .io = io },
         .retry_policy = options.retry_policy,
+        .request_timeout_ms = options.request_timeout_ms,
     };
 }
 

--- a/src/search/keenable/Client.zig
+++ b/src/search/keenable/Client.zig
@@ -41,9 +41,9 @@ pub const InitOptions = struct {
     /// that forgets to set it.
     app_title: []const u8,
     retry_policy: RetryPolicy = .{},
-    /// Per-attempt bound from an established connection to the end of the
-    /// response body, failing with `error.Timeout`; the connect phase is
-    /// not covered. `null` waits indefinitely.
+    /// Per-attempt wall-clock bound on non-streaming requests, from an
+    /// established connection to the end of the body (connect excluded);
+    /// exceeding it fails with `error.Timeout`. `null` waits indefinitely.
     request_timeout_ms: ?u32 = null,
 };
 
@@ -102,7 +102,7 @@ pub fn search(
         .{ .name = "X-API-Key", .value = self.api_key orelse "" },
     };
 
-    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, .{
+    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, self.request_timeout_ms, .{
         .location = .{ .url = url },
         .method = .POST,
         .payload = payload_buf.written(),

--- a/src/search/keenable/Client.zig
+++ b/src/search/keenable/Client.zig
@@ -29,6 +29,7 @@ base_url: []const u8,
 app_title: []const u8,
 http_client: std.http.Client,
 retry_policy: RetryPolicy,
+request_timeout_ms: ?u32,
 last_error: http.ErrorDetail = .{},
 
 pub const InitOptions = struct {
@@ -40,6 +41,10 @@ pub const InitOptions = struct {
     /// that forgets to set it.
     app_title: []const u8,
     retry_policy: RetryPolicy = .{},
+    /// Per-attempt bound from an established connection to the end of the
+    /// response body, failing with `error.Timeout`; the connect phase is
+    /// not covered. `null` waits indefinitely.
+    request_timeout_ms: ?u32 = null,
 };
 
 pub fn init(io: std.Io, allocator: std.mem.Allocator, api_key: ?[]const u8, options: InitOptions) Client {
@@ -50,6 +55,7 @@ pub fn init(io: std.Io, allocator: std.mem.Allocator, api_key: ?[]const u8, opti
         .app_title = options.app_title,
         .http_client = .{ .allocator = allocator, .io = io },
         .retry_policy = options.retry_policy,
+        .request_timeout_ms = options.request_timeout_ms,
     };
 }
 

--- a/src/search/tavily/Client.zig
+++ b/src/search/tavily/Client.zig
@@ -27,9 +27,9 @@ last_error: http.ErrorDetail = .{},
 pub const InitOptions = struct {
     base_url: []const u8 = "https://api.tavily.com",
     retry_policy: RetryPolicy = .{},
-    /// Per-attempt bound from an established connection to the end of the
-    /// response body, failing with `error.Timeout`; the connect phase is
-    /// not covered. `null` waits indefinitely.
+    /// Per-attempt wall-clock bound on non-streaming requests, from an
+    /// established connection to the end of the body (connect excluded);
+    /// exceeding it fails with `error.Timeout`. `null` waits indefinitely.
     request_timeout_ms: ?u32 = null,
 };
 
@@ -81,7 +81,7 @@ pub fn search(
         .{ .name = "Authorization", .value = auth },
     };
 
-    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, .{
+    return http.fetchJsonWithRetry(self.allocator, &self.http_client, self.retry_policy, self.request_timeout_ms, .{
         .location = .{ .url = url },
         .method = .POST,
         .payload = payload_buf.written(),

--- a/src/search/tavily/Client.zig
+++ b/src/search/tavily/Client.zig
@@ -21,11 +21,16 @@ api_key: []const u8,
 base_url: []const u8,
 http_client: std.http.Client,
 retry_policy: RetryPolicy,
+request_timeout_ms: ?u32,
 last_error: http.ErrorDetail = .{},
 
 pub const InitOptions = struct {
     base_url: []const u8 = "https://api.tavily.com",
     retry_policy: RetryPolicy = .{},
+    /// Per-attempt bound from an established connection to the end of the
+    /// response body, failing with `error.Timeout`; the connect phase is
+    /// not covered. `null` waits indefinitely.
+    request_timeout_ms: ?u32 = null,
 };
 
 pub fn init(io: std.Io, allocator: std.mem.Allocator, api_key: []const u8, options: InitOptions) Client {
@@ -35,6 +40,7 @@ pub fn init(io: std.Io, allocator: std.mem.Allocator, api_key: []const u8, optio
         .base_url = options.base_url,
         .http_client = .{ .allocator = allocator, .io = io },
         .retry_policy = options.retry_policy,
+        .request_timeout_ms = options.request_timeout_ms,
     };
 }
 


### PR DESCRIPTION
## Summary

Adds a request timeout to the shared HTTP layer, exposed as `InitOptions.request_timeout_ms` on every client (the four search clients, anthropic, openai/ollama, gemini) and forwarded by `provider.Client.InitOptions`. Motivation: lightpanda's `search` tool now goes through the search clients for every search (the DuckDuckGo scrape via libcurl is being removed on the browser side), and on the MCP server a single stalled request blocks the shared browser thread for every session.

## How it works

- `Watchdog` (in `http.zig`): a private `Interrupt` armed on the request's stream via the existing `armInterrupt`, plus a small thread that waits on an `Io.Event` with a deadline. At the deadline it `shutdown()`s the socket — the same mechanism Ctrl-C uses — so the blocking read fails instead of waiting on the server. A raw `std.Thread` rather than `io.concurrent` because consumers run a single-threaded `Io.Threaded`, where `concurrent` is unavailable and cancel is a no-op.
- `fetchCapturingRetryAfter` takes an optional `timeout_ms`, maps the resulting read error to `error.Timeout`, and poisons the connection through `InterruptGuard.poison`. That includes the race where the deadline lands just after the body completed, so a half-shut socket never returns to the pool. `stop()` joins the thread before `req.deinit` (LIFO with the interrupt guard).
- `fetchJsonWithRetry` takes `timeout_ms` as an explicit parameter (not `@hasField` off the client like `interrupt`), so every call site states its value and a client can't silently opt out. `error.Timeout` is not retryable, so the bound is one timeout per attempt.
- `fetchInterruptible` (used by the browser's codex auth flow) passes no timeout — unchanged behaviour.

## What it does not cover

- **The connect phase.** Zig 0.16's `std.http.Client.ConnectTcpOptions.timeout` is declared but never forwarded, and `Io.Threaded.netConnectIpPosix` has `@panic("TODO implement ... with timeout")`. A blackholed SYN still waits out the OS retry. Nothing to do about that outside std.
- **Streaming** (`streamLines`, and codex, which is streaming-only). LLM streams legitimately run for minutes; a single wall-clock deadline is the wrong shape there — they'd want an idle (per-read) timeout with a resettable deadline. Codex accepts `request_timeout_ms` for uniform provider init only.

## Why not `SO_RCVTIMEO`

It was the cheaper route, but `Io.Threaded.netReadPosix` maps `EAGAIN` to `errnoBug`, which panics in debug builds.

## Test

`http.test.watchdog turns a stalled response into error.Timeout`: a loopback listener that never `accept`s — the kernel completes the handshake into the backlog and buffers the request, so the client blocks in `receiveHead` until a 50 ms watchdog yields `error.Timeout`. `zig build test`: 107/107. The browser (`../browser`, depends on zenai by path) builds against this branch.
