### PR TITLE
provider: carry images in tool results and user parts on every backend

### DIFF
--- a/src/anthropic/Chat.zig
+++ b/src/anthropic/Chat.zig
@@ -204,7 +204,11 @@ fn dupeContentBlocks(self: *Chat, blocks: []const ContentBlockParam) std.mem.All
         if (block.name) |v| duped[i].name = try a.dupe(u8, v);
         if (block.input) |v| duped[i].input = try json.dupeValue(a, v);
         if (block.tool_use_id) |v| duped[i].tool_use_id = try a.dupe(u8, v);
-        if (block.content) |v| duped[i].content = try a.dupe(u8, v);
+        if (block.content) |v| duped[i].content = switch (v) {
+            .text => |t| .{ .text = try a.dupe(u8, t) },
+            .blocks => |b| .{ .blocks = try self.dupeContentBlocks(b) },
+        };
+        if (block.source) |v| duped[i].source = .{ .media_type = try a.dupe(u8, v.media_type), .data = try a.dupe(u8, v.data) };
         if (block.toolset_name) |v| duped[i].toolset_name = try a.dupe(u8, v);
         if (block.thinking) |v| duped[i].thinking = try a.dupe(u8, v);
         if (block.signature) |v| duped[i].signature = try a.dupe(u8, v);

--- a/src/anthropic/types.zig
+++ b/src/anthropic/types.zig
@@ -64,8 +64,11 @@ pub const ContentBlockParam = struct {
     input: ?std.json.Value = null,
     /// The tool_use ID this result responds to (type="tool_result").
     tool_use_id: ?[]const u8 = null,
-    /// Text content for tool result (type="tool_result").
-    content: ?[]const u8 = null,
+    /// Tool result content (type="tool_result"): plain text, or blocks when
+    /// the result carries images.
+    content: ?ToolResultContent = null,
+    /// Inline image (type="image").
+    source: ?ImageSource = null,
     /// Whether the tool result is an error (type="tool_result").
     is_error: ?bool = null,
     /// For a toolset member tool_use, the toolset family it belongs to; for a
@@ -75,6 +78,24 @@ pub const ContentBlockParam = struct {
     thinking: ?[]const u8 = null,
     /// Opaque signature for thinking continuation (type="thinking").
     signature: ?[]const u8 = null,
+};
+
+pub const ToolResultContent = union(enum) {
+    text: []const u8,
+    blocks: []const ContentBlockParam,
+
+    pub fn jsonStringify(self: ToolResultContent, jws: anytype) !void {
+        switch (self) {
+            .text => |t| try jws.write(t),
+            .blocks => |b| try jws.write(b),
+        }
+    }
+};
+
+pub const ImageSource = struct {
+    type: []const u8 = "base64",
+    media_type: []const u8,
+    data: []const u8,
 };
 
 /// A text block used for system prompts.

--- a/src/anthropic/types.zig
+++ b/src/anthropic/types.zig
@@ -84,12 +84,7 @@ pub const ToolResultContent = union(enum) {
     text: []const u8,
     blocks: []const ContentBlockParam,
 
-    pub fn jsonStringify(self: ToolResultContent, jws: anytype) !void {
-        switch (self) {
-            .text => |t| try jws.write(t),
-            .blocks => |b| try jws.write(b),
-        }
-    }
+    pub const jsonStringify = jsonutil.PayloadUnionMethods(@This()).jsonStringify;
 };
 
 pub const ImageSource = struct {

--- a/src/codex/Client.zig
+++ b/src/codex/Client.zig
@@ -180,7 +180,7 @@ test "setApiKey rebuilds the cached bearer value" {
 }
 
 test "Codex ResponsesRequest serializes store/include/reasoning.summary, omits max_output_tokens" {
-    const input = [_]types.ResponseInputItem{.{ .type = "message", .role = "user", .content = "hi" }};
+    const input = [_]types.ResponseInputItem{.{ .type = "message", .role = "user", .content = .{ .text = "hi" } }};
     const req: ResponsesRequest = .{
         .model = "gpt-5-codex",
         .input = &input,

--- a/src/json.zig
+++ b/src/json.zig
@@ -53,6 +53,19 @@ pub fn StringUnionMethods(comptime U: type) type {
     };
 }
 
+/// For a union whose active payload *is* the JSON value (text or a list):
+///
+///     pub const jsonStringify = jsonutil.PayloadUnionMethods(@This()).jsonStringify;
+pub fn PayloadUnionMethods(comptime U: type) type {
+    return struct {
+        pub fn jsonStringify(self: U, jws: anytype) !void {
+            switch (self) {
+                inline else => |v| try jws.write(v),
+            }
+        }
+    };
+}
+
 /// Deep-copy a `std.json.Value`, duplicating all owned strings and containers.
 pub fn dupeValue(a: std.mem.Allocator, value: std.json.Value) std.mem.Allocator.Error!std.json.Value {
     return switch (value) {

--- a/src/openai/ollama.zig
+++ b/src/openai/ollama.zig
@@ -31,6 +31,8 @@ pub const Message = struct {
     /// Names the tool a `role: "tool"` message answers (request only).
     tool_name: ?[]const u8 = null,
     tool_calls: ?[]const ToolCall = null,
+    /// Base64 images attached to the message (request only).
+    images: ?[]const []const u8 = null,
 };
 
 /// Request `options`. `num_ctx` is the field the `/v1` shim lacks.

--- a/src/openai/types.zig
+++ b/src/openai/types.zig
@@ -66,6 +66,9 @@ pub const Message = struct {
     role: ?Role = null,
     /// The text content of the message.
     content: ?[]const u8 = null,
+    /// Multimodal content (request only). Serialized as `content` in place
+    /// of the plain text when set.
+    content_parts: ?[]const ContentPart = null,
     /// Optional participant name.
     name: ?[]const u8 = null,
     /// Tool calls requested by the assistant (only for role=assistant).
@@ -74,6 +77,50 @@ pub const Message = struct {
     tool_call_id: ?[]const u8 = null,
     /// Refusal message from the model.
     refusal: ?[]const u8 = null,
+
+    pub fn jsonStringify(self: Message, jws: anytype) !void {
+        try jws.beginObject();
+        if (self.role) |v| {
+            try jws.objectField("role");
+            try jws.write(v);
+        }
+        if (self.content_parts) |parts| {
+            try jws.objectField("content");
+            try jws.write(parts);
+        } else if (self.content) |v| {
+            try jws.objectField("content");
+            try jws.write(v);
+        }
+        if (self.name) |v| {
+            try jws.objectField("name");
+            try jws.write(v);
+        }
+        if (self.tool_calls) |v| {
+            try jws.objectField("tool_calls");
+            try jws.write(v);
+        }
+        if (self.tool_call_id) |v| {
+            try jws.objectField("tool_call_id");
+            try jws.write(v);
+        }
+        if (self.refusal) |v| {
+            try jws.objectField("refusal");
+            try jws.write(v);
+        }
+        try jws.endObject();
+    }
+};
+
+/// One entry of a multimodal `content` array: `text` or `image_url`.
+pub const ContentPart = struct {
+    type: []const u8,
+    text: ?[]const u8 = null,
+    image_url: ?ImageUrl = null,
+};
+
+pub const ImageUrl = struct {
+    /// An https URL or a `data:<mime>;base64,<data>` URL.
+    url: []const u8,
 };
 
 // --- Tools ---
@@ -301,11 +348,32 @@ pub const ResponseReasoning = struct {
 pub const ResponseInputItem = struct {
     type: []const u8,
     role: ?[]const u8 = null,
-    content: ?[]const u8 = null,
+    content: ?ResponseContent = null,
     call_id: ?[]const u8 = null,
     name: ?[]const u8 = null,
     arguments: ?[]const u8 = null,
     output: ?[]const u8 = null,
+};
+
+/// `message` item content: plain text, or parts when it carries images.
+pub const ResponseContent = union(enum) {
+    text: []const u8,
+    parts: []const ResponseContentPart,
+
+    pub fn jsonStringify(self: ResponseContent, jws: anytype) !void {
+        switch (self) {
+            .text => |t| try jws.write(t),
+            .parts => |p| try jws.write(p),
+        }
+    }
+};
+
+/// `input_text` or `input_image`.
+pub const ResponseContentPart = struct {
+    type: []const u8,
+    text: ?[]const u8 = null,
+    /// An https URL or a `data:<mime>;base64,<data>` URL.
+    image_url: ?[]const u8 = null,
 };
 
 /// Request body for the responses endpoint.
@@ -559,7 +627,7 @@ test "ResponsesResponse extracts text and tool calls" {
 }
 
 test "ResponsesRequest serializes flat tools and reasoning" {
-    const input = [_]ResponseInputItem{.{ .type = "message", .role = "user", .content = "hi" }};
+    const input = [_]ResponseInputItem{.{ .type = "message", .role = "user", .content = .{ .text = "hi" } }};
     const tools = [_]ResponseTool{.{ .name = "goto", .description = "navigate" }};
     const req = ResponsesRequest{
         .model = "gpt-5.5",

--- a/src/openai/types.zig
+++ b/src/openai/types.zig
@@ -78,34 +78,25 @@ pub const Message = struct {
     /// Refusal message from the model.
     refusal: ?[]const u8 = null,
 
+    /// Default field emission, except that `content_parts` goes out as
+    /// `content` in place of the text.
     pub fn jsonStringify(self: Message, jws: anytype) !void {
         try jws.beginObject();
-        if (self.role) |v| {
-            try jws.objectField("role");
-            try jws.write(v);
-        }
-        if (self.content_parts) |parts| {
-            try jws.objectField("content");
-            try jws.write(parts);
-        } else if (self.content) |v| {
-            try jws.objectField("content");
-            try jws.write(v);
-        }
-        if (self.name) |v| {
-            try jws.objectField("name");
-            try jws.write(v);
-        }
-        if (self.tool_calls) |v| {
-            try jws.objectField("tool_calls");
-            try jws.write(v);
-        }
-        if (self.tool_call_id) |v| {
-            try jws.objectField("tool_call_id");
-            try jws.write(v);
-        }
-        if (self.refusal) |v| {
-            try jws.objectField("refusal");
-            try jws.write(v);
+        inline for (std.meta.fields(Message)) |f| {
+            if (comptime std.mem.eql(u8, f.name, "content_parts")) {
+                // Emitted under `content` below.
+            } else if (comptime std.mem.eql(u8, f.name, "content")) {
+                if (self.content_parts) |parts| {
+                    try jws.objectField("content");
+                    try jws.write(parts);
+                } else if (self.content) |v| {
+                    try jws.objectField("content");
+                    try jws.write(v);
+                }
+            } else if (@field(self, f.name)) |v| {
+                try jws.objectField(f.name);
+                try jws.write(v);
+            }
         }
         try jws.endObject();
     }
@@ -119,8 +110,24 @@ pub const ContentPart = struct {
 };
 
 pub const ImageUrl = struct {
-    /// An https URL or a `data:<mime>;base64,<data>` URL.
-    url: []const u8,
+    url: DataUrl,
+};
+
+/// Serializes as `data:<mime>;base64,<data>` without building the string:
+/// the payload is written in place, so an image costs no extra copy.
+pub const DataUrl = struct {
+    mime_type: []const u8,
+    data: []const u8,
+
+    pub fn jsonStringify(self: DataUrl, jws: anytype) !void {
+        try jws.beginWriteRaw();
+        try jws.writer.writeAll("\"data:");
+        try jws.writer.writeAll(self.mime_type);
+        try jws.writer.writeAll(";base64,");
+        try jws.writer.writeAll(self.data);
+        try jws.writer.writeByte('"');
+        jws.endWriteRaw();
+    }
 };
 
 // --- Tools ---
@@ -360,20 +367,14 @@ pub const ResponseContent = union(enum) {
     text: []const u8,
     parts: []const ResponseContentPart,
 
-    pub fn jsonStringify(self: ResponseContent, jws: anytype) !void {
-        switch (self) {
-            .text => |t| try jws.write(t),
-            .parts => |p| try jws.write(p),
-        }
-    }
+    pub const jsonStringify = jsonutil.PayloadUnionMethods(@This()).jsonStringify;
 };
 
 /// `input_text` or `input_image`.
 pub const ResponseContentPart = struct {
     type: []const u8,
     text: ?[]const u8 = null,
-    /// An https URL or a `data:<mime>;base64,<data>` URL.
-    image_url: ?[]const u8 = null,
+    image_url: ?DataUrl = null,
 };
 
 /// Request body for the responses endpoint.

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -35,6 +35,10 @@ pub const ToolResult = struct {
     id: []const u8,
     name: []const u8, // Required specifically by Gemini
     content: []const u8, // String representation of the result
+    /// Images the tool produced, alongside `content`. Anthropic and Gemini
+    /// carry them in the result itself; the OpenAI-style APIs only accept
+    /// text there, so they follow as a user message.
+    images: ?[]const ImageData = null,
     /// Signals that the tool call failed. Propagated to Anthropic's native
     /// `is_error` wire field; providers without an equivalent ignore it.
     is_error: bool = false,
@@ -142,8 +146,8 @@ pub const Message = struct {
     content: ?[]const u8 = null,
     tool_calls: ?[]const ToolCall = null,
     tool_results: ?[]const ToolResult = null,
-    /// Rich content parts (text + images). When set, takes precedence over `content` for
-    /// building provider content blocks. Currently only supported by Gemini.
+    /// Rich content parts (text + images). When set, takes precedence over
+    /// `content` for building provider content blocks.
     parts: ?[]const ContentPart = null,
 };
 
@@ -221,8 +225,20 @@ pub fn dupeToolResults(alloc: std.mem.Allocator, results: []const ToolResult) ![
             .id = try alloc.dupe(u8, tr.id),
             .name = try alloc.dupe(u8, tr.name),
             .content = try alloc.dupe(u8, tr.content),
+            .images = if (tr.images) |imgs| try dupeImages(alloc, imgs) else null,
             .is_error = tr.is_error,
             .thought_signature = if (tr.thought_signature) |ts| try alloc.dupe(u8, ts) else null,
+        };
+    }
+    return out;
+}
+
+pub fn dupeImages(alloc: std.mem.Allocator, images: []const ImageData) ![]const ImageData {
+    const out = try alloc.alloc(ImageData, images.len);
+    for (images, 0..) |img, i| {
+        out[i] = .{
+            .data = try alloc.dupe(u8, img.data),
+            .mime_type = try alloc.dupe(u8, img.mime_type),
         };
     }
     return out;
@@ -1719,6 +1735,9 @@ fn separateSystemMessages(allocator: std.mem.Allocator, messages: []const Messag
                     },
                     .thoughtSignature = res.thought_signature,
                 });
+                for (res.images orelse &.{}) |img| {
+                    try parts.append(allocator, .{ .inlineData = .{ .data = img.data, .mimeType = img.mime_type } });
+                }
             }
         }
 
@@ -1739,6 +1758,66 @@ fn messageText(msg: Message) ?[]const u8 {
     return null;
 }
 
+fn hasImage(parts: []const ContentPart) bool {
+    for (parts) |cp| if (cp == .image) return true;
+    return false;
+}
+
+fn dataUrl(allocator: std.mem.Allocator, img: ImageData) ![]const u8 {
+    return std.fmt.allocPrint(allocator, "data:{s};base64,{s}", .{ img.mime_type, img.data });
+}
+
+/// Caption for images that can't ride in the tool result itself.
+fn toolImageCaption(allocator: std.mem.Allocator, tool_name: []const u8) ![]const u8 {
+    return std.fmt.allocPrint(allocator, "Image returned by {s}", .{tool_name});
+}
+
+fn openAIContentParts(allocator: std.mem.Allocator, parts: []const ContentPart) ![]const openai_types.ContentPart {
+    var out: std.ArrayList(openai_types.ContentPart) = .empty;
+    for (parts) |cp| switch (cp) {
+        .text => |t| try out.append(allocator, .{ .type = "text", .text = t }),
+        .image => |img| try out.append(allocator, .{ .type = "image_url", .image_url = .{ .url = try dataUrl(allocator, img) } }),
+    };
+    return out.toOwnedSlice(allocator);
+}
+
+fn openAIImageParts(allocator: std.mem.Allocator, caption: []const u8, images: []const ImageData) ![]const openai_types.ContentPart {
+    var out: std.ArrayList(openai_types.ContentPart) = .empty;
+    try out.append(allocator, .{ .type = "text", .text = caption });
+    for (images) |img| {
+        try out.append(allocator, .{ .type = "image_url", .image_url = .{ .url = try dataUrl(allocator, img) } });
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+fn responsesContentParts(allocator: std.mem.Allocator, parts: []const ContentPart) ![]const openai_types.ResponseContentPart {
+    var out: std.ArrayList(openai_types.ResponseContentPart) = .empty;
+    for (parts) |cp| switch (cp) {
+        .text => |t| try out.append(allocator, .{ .type = "input_text", .text = t }),
+        .image => |img| try out.append(allocator, .{ .type = "input_image", .image_url = try dataUrl(allocator, img) }),
+    };
+    return out.toOwnedSlice(allocator);
+}
+
+fn responsesImageParts(allocator: std.mem.Allocator, caption: []const u8, images: []const ImageData) ![]const openai_types.ResponseContentPart {
+    var out: std.ArrayList(openai_types.ResponseContentPart) = .empty;
+    try out.append(allocator, .{ .type = "input_text", .text = caption });
+    for (images) |img| {
+        try out.append(allocator, .{ .type = "input_image", .image_url = try dataUrl(allocator, img) });
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+fn base64Images(allocator: std.mem.Allocator, parts: []const ContentPart) !?[]const []const u8 {
+    var out: std.ArrayList([]const u8) = .empty;
+    for (parts) |cp| switch (cp) {
+        .image => |img| try out.append(allocator, img.data),
+        .text => {},
+    };
+    if (out.items.len == 0) return null;
+    return try out.toOwnedSlice(allocator);
+}
+
 fn messagesToOpenAIMessages(allocator: std.mem.Allocator, messages: []const Message) ![]openai_types.Message {
     var out: std.ArrayList(openai_types.Message) = .empty;
 
@@ -1750,6 +1829,14 @@ fn messagesToOpenAIMessages(allocator: std.mem.Allocator, messages: []const Mess
                         .role = .tool,
                         .content = res.content,
                         .tool_call_id = res.id,
+                    });
+                }
+                // A tool message is text-only; images follow as the user's turn.
+                for (results) |res| {
+                    const images = res.images orelse continue;
+                    try out.append(allocator, .{
+                        .role = .user,
+                        .content_parts = try openAIImageParts(allocator, try toolImageCaption(allocator, res.name), images),
                     });
                 }
             } else {
@@ -1781,6 +1868,11 @@ fn messagesToOpenAIMessages(allocator: std.mem.Allocator, messages: []const Mess
             oai_tool_calls = oai_calls;
         }
 
+        const content_parts: ?[]const openai_types.ContentPart = if (msg.parts) |parts|
+            (if (hasImage(parts)) try openAIContentParts(allocator, parts) else null)
+        else
+            null;
+
         try out.append(allocator, .{
             .role = switch (msg.role) {
                 .system => .system,
@@ -1789,6 +1881,7 @@ fn messagesToOpenAIMessages(allocator: std.mem.Allocator, messages: []const Mess
                 .tool => unreachable,
             },
             .content = messageText(msg),
+            .content_parts = content_parts,
             .tool_calls = oai_tool_calls,
         });
     }
@@ -1810,6 +1903,16 @@ fn messagesToOllamaMessages(allocator: std.mem.Allocator, messages: []const Mess
                         .role = "tool",
                         .content = res.content,
                         .tool_name = res.name,
+                    });
+                }
+                for (results) |res| {
+                    const images = res.images orelse continue;
+                    var data = try allocator.alloc([]const u8, images.len);
+                    for (images, 0..) |img, i| data[i] = img.data;
+                    try out.append(allocator, .{
+                        .role = "user",
+                        .content = try toolImageCaption(allocator, res.name),
+                        .images = data,
                     });
                 }
             } else {
@@ -1840,6 +1943,7 @@ fn messagesToOllamaMessages(allocator: std.mem.Allocator, messages: []const Mess
             },
             .content = messageText(msg),
             .tool_calls = native_tool_calls,
+            .images = if (msg.parts) |parts| try base64Images(allocator, parts) else null,
         });
     }
 
@@ -1857,7 +1961,7 @@ fn messagesToAnthropicMessages(allocator: std.mem.Allocator, messages: []const M
             for (content_parts) |cp| {
                 switch (cp) {
                     .text => |t| try blocks.append(allocator, .{ .type = "text", .text = t }),
-                    .image => {},
+                    .image => |img| try blocks.append(allocator, .{ .type = "image", .source = .{ .media_type = img.mime_type, .data = img.data } }),
                 }
             }
         } else if (msg.content) |c| {
@@ -1882,7 +1986,7 @@ fn messagesToAnthropicMessages(allocator: std.mem.Allocator, messages: []const M
                 try blocks.append(allocator, .{
                     .type = "tool_result",
                     .tool_use_id = res.id,
-                    .content = res.content,
+                    .content = try anthropicToolResultContent(allocator, res),
                     .is_error = if (res.is_error) true else null,
                 });
             }
@@ -1892,6 +1996,16 @@ fn messagesToAnthropicMessages(allocator: std.mem.Allocator, messages: []const M
         try out.append(allocator, .{ .role = role, .content = try blocks.toOwnedSlice(allocator) });
     }
     return out.toOwnedSlice(allocator);
+}
+
+fn anthropicToolResultContent(allocator: std.mem.Allocator, res: ToolResult) !anthropic_types.ToolResultContent {
+    const images = res.images orelse return .{ .text = res.content };
+    var blocks: std.ArrayList(anthropic_types.ContentBlockParam) = .empty;
+    if (res.content.len > 0) try blocks.append(allocator, .{ .type = "text", .text = res.content });
+    for (images) |img| {
+        try blocks.append(allocator, .{ .type = "image", .source = .{ .media_type = img.mime_type, .data = img.data } });
+    }
+    return .{ .blocks = try blocks.toOwnedSlice(allocator) };
 }
 
 fn mapOpenAITools(allocator: std.mem.Allocator, tools: []const Tool) ![]openai_types.Tool {
@@ -1947,19 +2061,27 @@ fn messagesToOpenAIResponsesInput(allocator: std.mem.Allocator, messages: []cons
                         .output = res.content,
                     });
                 }
+                // A function output is text-only; images follow as the user's turn.
+                for (results) |res| {
+                    const images = res.images orelse continue;
+                    try out.append(allocator, .{
+                        .type = "message",
+                        .role = "user",
+                        .content = .{ .parts = try responsesImageParts(allocator, try toolImageCaption(allocator, res.name), images) },
+                    });
+                }
             }
             continue;
         }
 
-        const text_content: ?[]const u8 = if (msg.parts) |content_parts| blk: {
-            for (content_parts) |cp| switch (cp) {
-                .text => |t| break :blk t,
-                .image => {},
-            };
-            break :blk null;
-        } else msg.content;
+        const content: ?openai_types.ResponseContent = if (msg.parts) |parts|
+            (if (hasImage(parts)) .{ .parts = try responsesContentParts(allocator, parts) } else if (messageText(msg)) |t| .{ .text = t } else null)
+        else if (msg.content) |c|
+            .{ .text = c }
+        else
+            null;
 
-        if (text_content) |c| {
+        if (content) |c| {
             try out.append(allocator, .{
                 .type = "message",
                 .role = switch (msg.role) {
@@ -2623,4 +2745,106 @@ test "mapEffortToAnthropic pairs adaptive thinking with effort and headroom" {
 
 test "mapEffortToAnthropic respects caller-supplied max_tokens when already large" {
     try std.testing.expectEqual(@as(i32, 64000), mapEffortToAnthropic(.medium, 64000).max_tokens);
+}
+
+// Two turns: the model calls `screenshot`, the tool answers with text plus one
+// image. Each mapping must put the image where that API accepts one.
+fn imageToolResultConversation() [3]Message {
+    const images = &[_]ImageData{.{ .data = "iVBORw0KGgo=", .mime_type = "image/png" }};
+    return .{
+        .{ .role = .user, .content = "look" },
+        .{ .role = .assistant, .tool_calls = &.{.{ .id = "c1", .name = "screenshot", .arguments = null }} },
+        .{ .role = .tool, .tool_results = &.{.{ .id = "c1", .name = "screenshot", .content = "PNG, 1920px wide", .images = images }} },
+    };
+}
+
+fn stringifyForTest(allocator: std.mem.Allocator, value: anytype) ![]const u8 {
+    var buf: std.Io.Writer.Allocating = .init(allocator);
+    try std.json.Stringify.value(value, .{ .emit_null_optional_fields = false }, &buf.writer);
+    return buf.written();
+}
+
+test "tool result images: anthropic puts an image block inside tool_result" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const msgs = imageToolResultConversation();
+    const out = try messagesToAnthropicMessages(a, &msgs);
+    const json_out = try stringifyForTest(a, out);
+    try std.testing.expect(std.mem.find(u8, json_out, "\"type\":\"tool_result\",\"tool_use_id\":\"c1\",\"content\":[{\"type\":\"text\",\"text\":\"PNG, 1920px wide\"},{\"type\":\"image\",\"source\":{\"type\":\"base64\",\"media_type\":\"image/png\",\"data\":\"iVBORw0KGgo=\"}}]") != null);
+}
+
+test "tool result images: gemini appends inlineData after the functionResponse" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const msgs = imageToolResultConversation();
+    const out = try separateSystemMessages(a, &msgs);
+    const json_out = try stringifyForTest(a, out.contents);
+    const fr = std.mem.find(u8, json_out, "\"functionResponse\"") orelse return error.TestUnexpectedResult;
+    const inline_data = std.mem.find(u8, json_out, "\"inlineData\":{\"data\":\"iVBORw0KGgo=\",\"mimeType\":\"image/png\"}") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(inline_data > fr);
+}
+
+test "tool result images: openai chat follows the tool message with a user image" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const msgs = imageToolResultConversation();
+    const out = try messagesToOpenAIMessages(a, &msgs);
+    try std.testing.expectEqual(4, out.len);
+    try std.testing.expectEqual(openai_types.Role.tool, out[2].role.?);
+    try std.testing.expectEqual(openai_types.Role.user, out[3].role.?);
+    const json_out = try stringifyForTest(a, out[3]);
+    try std.testing.expect(std.mem.find(u8, json_out, "\"content\":[{\"type\":\"text\",\"text\":\"Image returned by screenshot\"},{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/png;base64,iVBORw0KGgo=\"}}]") != null);
+    try std.testing.expect(std.mem.find(u8, json_out, "content_parts") == null);
+}
+
+test "tool result images: openai responses follows the output with an input_image" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const msgs = imageToolResultConversation();
+    const out = try messagesToOpenAIResponsesInput(a, &msgs, "developer");
+    try std.testing.expectEqual(4, out.len);
+    try std.testing.expectEqualStrings("function_call_output", out[2].type);
+    const json_out = try stringifyForTest(a, out[3]);
+    try std.testing.expect(std.mem.find(u8, json_out, "\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"Image returned by screenshot\"},{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,iVBORw0KGgo=\"}]") != null);
+}
+
+test "tool result images: ollama follows the tool message with images" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const msgs = imageToolResultConversation();
+    const out = try messagesToOllamaMessages(a, &msgs);
+    try std.testing.expectEqual(4, out.len);
+    const json_out = try stringifyForTest(a, out[3]);
+    try std.testing.expect(std.mem.find(u8, json_out, "\"role\":\"user\",\"content\":\"Image returned by screenshot\",\"images\":[\"iVBORw0KGgo=\"]") != null);
+}
+
+test "user image parts reach anthropic, openai chat and responses" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const parts = &[_]ContentPart{ .{ .text = "what is this?" }, .{ .image = .{ .data = "AAAA", .mime_type = "image/jpeg" } } };
+    const msgs = [_]Message{.{ .role = .user, .parts = parts }};
+
+    const anth = try stringifyForTest(a, try messagesToAnthropicMessages(a, &msgs));
+    try std.testing.expect(std.mem.find(u8, anth, "{\"type\":\"image\",\"source\":{\"type\":\"base64\",\"media_type\":\"image/jpeg\",\"data\":\"AAAA\"}}") != null);
+
+    const chat = try stringifyForTest(a, try messagesToOpenAIMessages(a, &msgs));
+    try std.testing.expect(std.mem.find(u8, chat, "{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/jpeg;base64,AAAA\"}}") != null);
+
+    const responses = try stringifyForTest(a, try messagesToOpenAIResponsesInput(a, &msgs, "developer"));
+    try std.testing.expect(std.mem.find(u8, responses, "{\"type\":\"input_image\",\"image_url\":\"data:image/jpeg;base64,AAAA\"}") != null);
+
+    const ollama = try stringifyForTest(a, try messagesToOllamaMessages(a, &msgs));
+    try std.testing.expect(std.mem.find(u8, ollama, "\"images\":[\"AAAA\"]") != null);
 }

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -35,10 +35,9 @@ pub const ToolResult = struct {
     id: []const u8,
     name: []const u8, // Required specifically by Gemini
     content: []const u8, // String representation of the result
-    /// Images the tool produced, alongside `content`. Anthropic and Gemini
-    /// carry them in the result itself; the OpenAI-style APIs only accept
-    /// text there, so they follow as a user message.
-    images: ?[]const ImageData = null,
+    /// Rich content (text + images) for backends that can carry it in the
+    /// result; `content` stays the text-only form. See `splitToolImages`.
+    parts: ?[]const ContentPart = null,
     /// Signals that the tool call failed. Propagated to Anthropic's native
     /// `is_error` wire field; providers without an equivalent ignore it.
     is_error: bool = false,
@@ -225,20 +224,9 @@ pub fn dupeToolResults(alloc: std.mem.Allocator, results: []const ToolResult) ![
             .id = try alloc.dupe(u8, tr.id),
             .name = try alloc.dupe(u8, tr.name),
             .content = try alloc.dupe(u8, tr.content),
-            .images = if (tr.images) |imgs| try dupeImages(alloc, imgs) else null,
+            .parts = if (tr.parts) |ps| try dupeParts(alloc, ps) else null,
             .is_error = tr.is_error,
             .thought_signature = if (tr.thought_signature) |ts| try alloc.dupe(u8, ts) else null,
-        };
-    }
-    return out;
-}
-
-pub fn dupeImages(alloc: std.mem.Allocator, images: []const ImageData) ![]const ImageData {
-    const out = try alloc.alloc(ImageData, images.len);
-    for (images, 0..) |img, i| {
-        out[i] = .{
-            .data = try alloc.dupe(u8, img.data),
-            .mime_type = try alloc.dupe(u8, img.mime_type),
         };
     }
     return out;
@@ -1735,9 +1723,10 @@ fn separateSystemMessages(allocator: std.mem.Allocator, messages: []const Messag
                     },
                     .thoughtSignature = res.thought_signature,
                 });
-                for (res.images orelse &.{}) |img| {
-                    try parts.append(allocator, .{ .inlineData = .{ .data = img.data, .mimeType = img.mime_type } });
-                }
+                for (res.parts orelse &.{}) |cp| switch (cp) {
+                    .image => |img| try parts.append(allocator, .{ .inlineData = .{ .data = img.data, .mimeType = img.mime_type } }),
+                    .text => {},
+                };
             }
         }
 
@@ -1758,56 +1747,77 @@ fn messageText(msg: Message) ?[]const u8 {
     return null;
 }
 
+/// The OpenAI-style APIs accept only text in a tool message. Move each tool
+/// turn's image parts into a user turn right after it, captioned with the
+/// tool's name; the tool message keeps `content`. Returns the input when no
+/// tool result carries an image.
+fn splitToolImages(allocator: std.mem.Allocator, messages: []const Message) ![]const Message {
+    var any = false;
+    for (messages) |msg| {
+        for (msg.tool_results orelse &.{}) |res| any = any or hasImage(res.parts orelse &.{});
+    }
+    if (!any) return messages;
+
+    var out: std.ArrayList(Message) = .empty;
+    for (messages) |msg| {
+        const results = msg.tool_results orelse {
+            try out.append(allocator, msg);
+            continue;
+        };
+        const stripped = try allocator.alloc(ToolResult, results.len);
+        var images: std.ArrayList(ContentPart) = .empty;
+        for (results, 0..) |res, i| {
+            stripped[i] = res;
+            stripped[i].parts = null;
+            if (!hasImage(res.parts orelse &.{})) continue;
+            try images.append(allocator, .{ .text = try std.fmt.allocPrint(allocator, "Image returned by {s}", .{res.name}) });
+            for (res.parts.?) |cp| {
+                if (cp == .image) try images.append(allocator, cp);
+            }
+        }
+        var tool_msg = msg;
+        tool_msg.tool_results = stripped;
+        try out.append(allocator, tool_msg);
+        if (images.items.len > 0) {
+            try out.append(allocator, .{ .role = .user, .parts = try images.toOwnedSlice(allocator) });
+        }
+    }
+    return out.toOwnedSlice(allocator);
+}
+
 fn hasImage(parts: []const ContentPart) bool {
     for (parts) |cp| if (cp == .image) return true;
     return false;
 }
 
-fn dataUrl(allocator: std.mem.Allocator, img: ImageData) ![]const u8 {
-    return std.fmt.allocPrint(allocator, "data:{s};base64,{s}", .{ img.mime_type, img.data });
-}
-
-/// Caption for images that can't ride in the tool result itself.
-fn toolImageCaption(allocator: std.mem.Allocator, tool_name: []const u8) ![]const u8 {
-    return std.fmt.allocPrint(allocator, "Image returned by {s}", .{tool_name});
-}
-
 fn openAIContentParts(allocator: std.mem.Allocator, parts: []const ContentPart) ![]const openai_types.ContentPart {
-    var out: std.ArrayList(openai_types.ContentPart) = .empty;
-    for (parts) |cp| switch (cp) {
-        .text => |t| try out.append(allocator, .{ .type = "text", .text = t }),
-        .image => |img| try out.append(allocator, .{ .type = "image_url", .image_url = .{ .url = try dataUrl(allocator, img) } }),
+    const out = try allocator.alloc(openai_types.ContentPart, parts.len);
+    for (parts, 0..) |cp, i| out[i] = switch (cp) {
+        .text => |t| .{ .type = "text", .text = t },
+        .image => |img| .{ .type = "image_url", .image_url = .{ .url = .{ .mime_type = img.mime_type, .data = img.data } } },
     };
-    return out.toOwnedSlice(allocator);
-}
-
-fn openAIImageParts(allocator: std.mem.Allocator, caption: []const u8, images: []const ImageData) ![]const openai_types.ContentPart {
-    var out: std.ArrayList(openai_types.ContentPart) = .empty;
-    try out.append(allocator, .{ .type = "text", .text = caption });
-    for (images) |img| {
-        try out.append(allocator, .{ .type = "image_url", .image_url = .{ .url = try dataUrl(allocator, img) } });
-    }
-    return out.toOwnedSlice(allocator);
+    return out;
 }
 
 fn responsesContentParts(allocator: std.mem.Allocator, parts: []const ContentPart) ![]const openai_types.ResponseContentPart {
-    var out: std.ArrayList(openai_types.ResponseContentPart) = .empty;
-    for (parts) |cp| switch (cp) {
-        .text => |t| try out.append(allocator, .{ .type = "input_text", .text = t }),
-        .image => |img| try out.append(allocator, .{ .type = "input_image", .image_url = try dataUrl(allocator, img) }),
+    const out = try allocator.alloc(openai_types.ResponseContentPart, parts.len);
+    for (parts, 0..) |cp, i| out[i] = switch (cp) {
+        .text => |t| .{ .type = "input_text", .text = t },
+        .image => |img| .{ .type = "input_image", .image_url = .{ .mime_type = img.mime_type, .data = img.data } },
     };
-    return out.toOwnedSlice(allocator);
+    return out;
 }
 
-fn responsesImageParts(allocator: std.mem.Allocator, caption: []const u8, images: []const ImageData) ![]const openai_types.ResponseContentPart {
-    var out: std.ArrayList(openai_types.ResponseContentPart) = .empty;
-    try out.append(allocator, .{ .type = "input_text", .text = caption });
-    for (images) |img| {
-        try out.append(allocator, .{ .type = "input_image", .image_url = try dataUrl(allocator, img) });
-    }
-    return out.toOwnedSlice(allocator);
+fn anthropicBlocks(allocator: std.mem.Allocator, parts: []const ContentPart) ![]const anthropic_types.ContentBlockParam {
+    const out = try allocator.alloc(anthropic_types.ContentBlockParam, parts.len);
+    for (parts, 0..) |cp, i| out[i] = switch (cp) {
+        .text => |t| .{ .type = "text", .text = t },
+        .image => |img| .{ .type = "image", .source = .{ .media_type = img.mime_type, .data = img.data } },
+    };
+    return out;
 }
 
+/// Ollama carries images beside the text, as bare base64.
 fn base64Images(allocator: std.mem.Allocator, parts: []const ContentPart) !?[]const []const u8 {
     var out: std.ArrayList([]const u8) = .empty;
     for (parts) |cp| switch (cp) {
@@ -1818,7 +1828,8 @@ fn base64Images(allocator: std.mem.Allocator, parts: []const ContentPart) !?[]co
     return try out.toOwnedSlice(allocator);
 }
 
-fn messagesToOpenAIMessages(allocator: std.mem.Allocator, messages: []const Message) ![]openai_types.Message {
+fn messagesToOpenAIMessages(allocator: std.mem.Allocator, input: []const Message) ![]openai_types.Message {
+    const messages = try splitToolImages(allocator, input);
     var out: std.ArrayList(openai_types.Message) = .empty;
 
     for (messages) |msg| {
@@ -1829,14 +1840,6 @@ fn messagesToOpenAIMessages(allocator: std.mem.Allocator, messages: []const Mess
                         .role = .tool,
                         .content = res.content,
                         .tool_call_id = res.id,
-                    });
-                }
-                // A tool message is text-only; images follow as the user's turn.
-                for (results) |res| {
-                    const images = res.images orelse continue;
-                    try out.append(allocator, .{
-                        .role = .user,
-                        .content_parts = try openAIImageParts(allocator, try toolImageCaption(allocator, res.name), images),
                     });
                 }
             } else {
@@ -1868,11 +1871,6 @@ fn messagesToOpenAIMessages(allocator: std.mem.Allocator, messages: []const Mess
             oai_tool_calls = oai_calls;
         }
 
-        const content_parts: ?[]const openai_types.ContentPart = if (msg.parts) |parts|
-            (if (hasImage(parts)) try openAIContentParts(allocator, parts) else null)
-        else
-            null;
-
         try out.append(allocator, .{
             .role = switch (msg.role) {
                 .system => .system,
@@ -1881,7 +1879,7 @@ fn messagesToOpenAIMessages(allocator: std.mem.Allocator, messages: []const Mess
                 .tool => unreachable,
             },
             .content = messageText(msg),
-            .content_parts = content_parts,
+            .content_parts = if (msg.parts) |parts| try openAIContentParts(allocator, parts) else null,
             .tool_calls = oai_tool_calls,
         });
     }
@@ -1892,7 +1890,8 @@ fn messagesToOpenAIMessages(allocator: std.mem.Allocator, messages: []const Mess
 /// Like `messagesToOpenAIMessages`, but keeps tool-call arguments as objects
 /// (not stringified) and answers tool results with `tool_name` (Ollama matches
 /// by name, not id).
-fn messagesToOllamaMessages(allocator: std.mem.Allocator, messages: []const Message) ![]ollama_native.Message {
+fn messagesToOllamaMessages(allocator: std.mem.Allocator, input: []const Message) ![]ollama_native.Message {
+    const messages = try splitToolImages(allocator, input);
     var out: std.ArrayList(ollama_native.Message) = .empty;
 
     for (messages) |msg| {
@@ -1903,16 +1902,6 @@ fn messagesToOllamaMessages(allocator: std.mem.Allocator, messages: []const Mess
                         .role = "tool",
                         .content = res.content,
                         .tool_name = res.name,
-                    });
-                }
-                for (results) |res| {
-                    const images = res.images orelse continue;
-                    var data = try allocator.alloc([]const u8, images.len);
-                    for (images, 0..) |img, i| data[i] = img.data;
-                    try out.append(allocator, .{
-                        .role = "user",
-                        .content = try toolImageCaption(allocator, res.name),
-                        .images = data,
                     });
                 }
             } else {
@@ -1958,12 +1947,7 @@ fn messagesToAnthropicMessages(allocator: std.mem.Allocator, messages: []const M
         var blocks: std.ArrayList(anthropic_types.ContentBlockParam) = .empty;
 
         if (msg.parts) |content_parts| {
-            for (content_parts) |cp| {
-                switch (cp) {
-                    .text => |t| try blocks.append(allocator, .{ .type = "text", .text = t }),
-                    .image => |img| try blocks.append(allocator, .{ .type = "image", .source = .{ .media_type = img.mime_type, .data = img.data } }),
-                }
-            }
+            try blocks.appendSlice(allocator, try anthropicBlocks(allocator, content_parts));
         } else if (msg.content) |c| {
             try blocks.append(allocator, .{ .type = "text", .text = c });
         }
@@ -1999,13 +1983,8 @@ fn messagesToAnthropicMessages(allocator: std.mem.Allocator, messages: []const M
 }
 
 fn anthropicToolResultContent(allocator: std.mem.Allocator, res: ToolResult) !anthropic_types.ToolResultContent {
-    const images = res.images orelse return .{ .text = res.content };
-    var blocks: std.ArrayList(anthropic_types.ContentBlockParam) = .empty;
-    if (res.content.len > 0) try blocks.append(allocator, .{ .type = "text", .text = res.content });
-    for (images) |img| {
-        try blocks.append(allocator, .{ .type = "image", .source = .{ .media_type = img.mime_type, .data = img.data } });
-    }
-    return .{ .blocks = try blocks.toOwnedSlice(allocator) };
+    const parts = res.parts orelse return .{ .text = res.content };
+    return .{ .blocks = try anthropicBlocks(allocator, parts) };
 }
 
 fn mapOpenAITools(allocator: std.mem.Allocator, tools: []const Tool) ![]openai_types.Tool {
@@ -2048,7 +2027,8 @@ fn codexRequest(model: []const u8, input: []const openai_types.ResponseInputItem
 /// assistant tool call becomes a `function_call` item and each tool result a
 /// `function_call_output` item, rather than the role-tagged messages chat
 /// completions uses.
-fn messagesToOpenAIResponsesInput(allocator: std.mem.Allocator, messages: []const Message, system_role: []const u8) ![]openai_types.ResponseInputItem {
+fn messagesToOpenAIResponsesInput(allocator: std.mem.Allocator, input: []const Message, system_role: []const u8) ![]openai_types.ResponseInputItem {
+    const messages = try splitToolImages(allocator, input);
     var out: std.ArrayList(openai_types.ResponseInputItem) = .empty;
 
     for (messages) |msg| {
@@ -2061,21 +2041,12 @@ fn messagesToOpenAIResponsesInput(allocator: std.mem.Allocator, messages: []cons
                         .output = res.content,
                     });
                 }
-                // A function output is text-only; images follow as the user's turn.
-                for (results) |res| {
-                    const images = res.images orelse continue;
-                    try out.append(allocator, .{
-                        .type = "message",
-                        .role = "user",
-                        .content = .{ .parts = try responsesImageParts(allocator, try toolImageCaption(allocator, res.name), images) },
-                    });
-                }
             }
             continue;
         }
 
         const content: ?openai_types.ResponseContent = if (msg.parts) |parts|
-            (if (hasImage(parts)) .{ .parts = try responsesContentParts(allocator, parts) } else if (messageText(msg)) |t| .{ .text = t } else null)
+            .{ .parts = try responsesContentParts(allocator, parts) }
         else if (msg.content) |c|
             .{ .text = c }
         else
@@ -2747,88 +2718,58 @@ test "mapEffortToAnthropic respects caller-supplied max_tokens when already larg
     try std.testing.expectEqual(@as(i32, 64000), mapEffortToAnthropic(.medium, 64000).max_tokens);
 }
 
-// Two turns: the model calls `screenshot`, the tool answers with text plus one
-// image. Each mapping must put the image where that API accepts one.
-fn imageToolResultConversation() [3]Message {
-    const images = &[_]ImageData{.{ .data = "iVBORw0KGgo=", .mime_type = "image/png" }};
-    return .{
-        .{ .role = .user, .content = "look" },
-        .{ .role = .assistant, .tool_calls = &.{.{ .id = "c1", .name = "screenshot", .arguments = null }} },
-        .{ .role = .tool, .tool_results = &.{.{ .id = "c1", .name = "screenshot", .content = "PNG, 1920px wide", .images = images }} },
-    };
-}
-
 fn stringifyForTest(allocator: std.mem.Allocator, value: anytype) ![]const u8 {
     var buf: std.Io.Writer.Allocating = .init(allocator);
     try std.json.Stringify.value(value, .{ .emit_null_optional_fields = false }, &buf.writer);
     return buf.written();
 }
 
-test "tool result images: anthropic puts an image block inside tool_result" {
+test "tool result parts land where each API accepts an image" {
     var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();
 
-    const msgs = imageToolResultConversation();
-    const out = try messagesToAnthropicMessages(a, &msgs);
-    const json_out = try stringifyForTest(a, out);
-    try std.testing.expect(std.mem.find(u8, json_out, "\"type\":\"tool_result\",\"tool_use_id\":\"c1\",\"content\":[{\"type\":\"text\",\"text\":\"PNG, 1920px wide\"},{\"type\":\"image\",\"source\":{\"type\":\"base64\",\"media_type\":\"image/png\",\"data\":\"iVBORw0KGgo=\"}}]") != null);
-}
+    // The model calls `screenshot`; the tool answers with text plus one image.
+    const msgs = [_]Message{
+        .{ .role = .user, .content = "look" },
+        .{ .role = .assistant, .tool_calls = &.{.{ .id = "c1", .name = "screenshot", .arguments = null }} },
+        .{ .role = .tool, .tool_results = &.{.{
+            .id = "c1",
+            .name = "screenshot",
+            .content = "PNG, 1920px wide",
+            .parts = &.{ .{ .text = "PNG, 1920px wide" }, .{ .image = .{ .data = "iVBORw0KGgo=", .mime_type = "image/png" } } },
+        }} },
+    };
 
-test "tool result images: gemini appends inlineData after the functionResponse" {
-    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
-    defer arena.deinit();
-    const a = arena.allocator();
+    // Anthropic: inside the tool_result.
+    const anth = try stringifyForTest(a, try messagesToAnthropicMessages(a, &msgs));
+    try std.testing.expect(std.mem.find(u8, anth, "\"type\":\"tool_result\",\"tool_use_id\":\"c1\",\"content\":[{\"type\":\"text\",\"text\":\"PNG, 1920px wide\"},{\"type\":\"image\",\"source\":{\"type\":\"base64\",\"media_type\":\"image/png\",\"data\":\"iVBORw0KGgo=\"}}]") != null);
 
-    const msgs = imageToolResultConversation();
-    const out = try separateSystemMessages(a, &msgs);
-    const json_out = try stringifyForTest(a, out.contents);
-    const fr = std.mem.find(u8, json_out, "\"functionResponse\"") orelse return error.TestUnexpectedResult;
-    const inline_data = std.mem.find(u8, json_out, "\"inlineData\":{\"data\":\"iVBORw0KGgo=\",\"mimeType\":\"image/png\"}") orelse return error.TestUnexpectedResult;
+    // Gemini: an inlineData part after the functionResponse.
+    const gem = try stringifyForTest(a, (try separateSystemMessages(a, &msgs)).contents);
+    const fr = std.mem.find(u8, gem, "\"functionResponse\"") orelse return error.TestUnexpectedResult;
+    const inline_data = std.mem.find(u8, gem, "\"inlineData\":{\"data\":\"iVBORw0KGgo=\",\"mimeType\":\"image/png\"}") orelse return error.TestUnexpectedResult;
     try std.testing.expect(inline_data > fr);
+
+    // OpenAI chat, Responses, Ollama: a captioned user turn after the tool message.
+    const chat = try messagesToOpenAIMessages(a, &msgs);
+    try std.testing.expectEqual(4, chat.len);
+    try std.testing.expectEqualStrings("PNG, 1920px wide", chat[2].content.?);
+    const chat_json = try stringifyForTest(a, chat[3]);
+    try std.testing.expect(std.mem.find(u8, chat_json, "\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Image returned by screenshot\"},{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/png;base64,iVBORw0KGgo=\"}}]") != null);
+
+    const responses = try messagesToOpenAIResponsesInput(a, &msgs, "developer");
+    try std.testing.expectEqual(4, responses.len);
+    const responses_json = try stringifyForTest(a, responses[3]);
+    try std.testing.expect(std.mem.find(u8, responses_json, "\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"Image returned by screenshot\"},{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,iVBORw0KGgo=\"}]") != null);
+
+    const ollama = try messagesToOllamaMessages(a, &msgs);
+    try std.testing.expectEqual(4, ollama.len);
+    const ollama_json = try stringifyForTest(a, ollama[3]);
+    try std.testing.expect(std.mem.find(u8, ollama_json, "\"role\":\"user\",\"content\":\"Image returned by screenshot\",\"images\":[\"iVBORw0KGgo=\"]") != null);
 }
 
-test "tool result images: openai chat follows the tool message with a user image" {
-    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
-    defer arena.deinit();
-    const a = arena.allocator();
-
-    const msgs = imageToolResultConversation();
-    const out = try messagesToOpenAIMessages(a, &msgs);
-    try std.testing.expectEqual(4, out.len);
-    try std.testing.expectEqual(openai_types.Role.tool, out[2].role.?);
-    try std.testing.expectEqual(openai_types.Role.user, out[3].role.?);
-    const json_out = try stringifyForTest(a, out[3]);
-    try std.testing.expect(std.mem.find(u8, json_out, "\"content\":[{\"type\":\"text\",\"text\":\"Image returned by screenshot\"},{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/png;base64,iVBORw0KGgo=\"}}]") != null);
-    try std.testing.expect(std.mem.find(u8, json_out, "content_parts") == null);
-}
-
-test "tool result images: openai responses follows the output with an input_image" {
-    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
-    defer arena.deinit();
-    const a = arena.allocator();
-
-    const msgs = imageToolResultConversation();
-    const out = try messagesToOpenAIResponsesInput(a, &msgs, "developer");
-    try std.testing.expectEqual(4, out.len);
-    try std.testing.expectEqualStrings("function_call_output", out[2].type);
-    const json_out = try stringifyForTest(a, out[3]);
-    try std.testing.expect(std.mem.find(u8, json_out, "\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"Image returned by screenshot\"},{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,iVBORw0KGgo=\"}]") != null);
-}
-
-test "tool result images: ollama follows the tool message with images" {
-    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
-    defer arena.deinit();
-    const a = arena.allocator();
-
-    const msgs = imageToolResultConversation();
-    const out = try messagesToOllamaMessages(a, &msgs);
-    try std.testing.expectEqual(4, out.len);
-    const json_out = try stringifyForTest(a, out[3]);
-    try std.testing.expect(std.mem.find(u8, json_out, "\"role\":\"user\",\"content\":\"Image returned by screenshot\",\"images\":[\"iVBORw0KGgo=\"]") != null);
-}
-
-test "user image parts reach anthropic, openai chat and responses" {
+test "user image parts reach every backend" {
     var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();
@@ -2840,7 +2781,8 @@ test "user image parts reach anthropic, openai chat and responses" {
     try std.testing.expect(std.mem.find(u8, anth, "{\"type\":\"image\",\"source\":{\"type\":\"base64\",\"media_type\":\"image/jpeg\",\"data\":\"AAAA\"}}") != null);
 
     const chat = try stringifyForTest(a, try messagesToOpenAIMessages(a, &msgs));
-    try std.testing.expect(std.mem.find(u8, chat, "{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/jpeg;base64,AAAA\"}}") != null);
+    try std.testing.expect(std.mem.find(u8, chat, "\"content\":[{\"type\":\"text\",\"text\":\"what is this?\"},{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/jpeg;base64,AAAA\"}}]") != null);
+    try std.testing.expect(std.mem.find(u8, chat, "content_parts") == null);
 
     const responses = try stringifyForTest(a, try messagesToOpenAIResponsesInput(a, &msgs, "developer"));
     try std.testing.expect(std.mem.find(u8, responses, "{\"type\":\"input_image\",\"image_url\":\"data:image/jpeg;base64,AAAA\"}") != null);


### PR DESCRIPTION
`ToolResult` gains `parts: ?[]const ContentPart` — the same text-and-images list `Message` already uses — so a tool (Lightpanda's `screenshot`) can hand the model a picture; `content` stays the text-only form. Where each API accepts it:

- Anthropic: `image` blocks inside `tool_result.content` (which is now text-or-blocks).
- Gemini: `inlineData` parts right after the `functionResponse`.
- OpenAI chat, Responses, Ollama: a single `splitToolImages` pre-pass rewrites a tool turn with images into the text-only tool message followed by a `user` turn (`image_url` / `input_image` / `images`) captioned `Image returned by <tool>`; the mappers themselves stay single-purpose.

User-message image `parts` were only mapped for Gemini; they now reach Anthropic, OpenAI chat, Responses and Ollama through the same part mappers, so attachments work on every backend.

No capability flag: every mapping has a real image path, so a non-vision model surfaces as the API's own error rather than a silent drop.

Wire types: Anthropic `ContentBlockParam.source` + `ToolResultContent`; OpenAI `Message.content_parts` emitted as `content` by a comptime field loop (response parsing untouched, new fields can't be dropped); `ResponseInputItem.content` is `ResponseContent`; `DataUrl` serializes `data:<mime>;base64,<data>` in place so a base64 payload is never copied per request; Ollama `Message.images`. The text-or-list unions share `jsonutil.PayloadUnionMethods`.

Tests: one tool-result test asserting the wire shape on all five backends, one for user parts; 109/109.
