### PR TITLE
ci: run zig fmt and zig build test on GitHub Actions

### DIFF
--- a/.github/workflows/zig-test.yml
+++ b/.github/workflows/zig-test.yml
@@ -1,0 +1,63 @@
+name: zig-test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/**"
+      - "src/**"
+      - "build.zig"
+      - "build.zig.zon"
+
+  pull_request:
+    # By default GH trigger on types opened, synchronize and reopened.
+    # see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # Since we skip the job when the PR is in draft state, we want to force CI
+    # running when the PR is marked ready_for_review w/o other change.
+    # see https://github.com/orgs/community/discussions/25722#discussioncomment-3248917
+    types: [opened, synchronize, reopened, ready_for_review]
+
+    paths:
+      - ".github/**"
+      - "src/**"
+      - "build.zig"
+      - "build.zig.zon"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  zig-fmt:
+    name: zig fmt
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Zig version used from the `minimum_zig_version` field in build.zig.zon
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+
+      - name: Run zig fmt
+        run: zig fmt --check ./
+
+  zig-test:
+    name: zig test
+    needs: zig-fmt
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Zig version used from the `minimum_zig_version` field in build.zig.zon
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+
+      - name: zig build test
+        run: zig build test


### PR DESCRIPTION
The repository had no CI, so compile errors in code paths the tests do not cover could reach `main` unnoticed (see #14 and #15).

This adds `.github/workflows/zig-test.yml`, modelled on the browser repository's workflow of the same name:

- `zig fmt --check ./`
- `zig build test`, gated on the fmt job

It runs on pushes to `main` and on non-draft pull requests, filtered to `src/`, `build.zig`, `build.zig.zon` and `.github/`, and can be triggered manually. The Zig version is picked up from `minimum_zig_version` in `build.zig.zon` by `mlugg/setup-zig`. Action versions are pinned to the same SHAs the browser repository uses.